### PR TITLE
feat(android): create a circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+
+version: 2.1
+
+orbs:
+  gradle: circleci/gradle@3.0.0
+
+matrix_executors: &matrix_executors
+  parameters:
+    executor:
+      - name: gradle/default
+        tag: "8.7"
+
+workflows:
+  unit-tests:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - gradle/test:
+          matrix:
+            <<: *matrix_executors
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,33 @@
 
-version: 2.1
+version: '2.1'
 
 orbs:
-  gradle: circleci/gradle@3.0.0
+  android: circleci/android@2.5
 
-matrix_executors: &matrix_executors
-  parameters:
+jobs:
+  unit-test:
     executor:
-      - name: gradle/default
-        tag: "8.7"
+      name: android/android-machine
+      resource-class: large
+      tag: default
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - android/run-tests:
+          test-command: ./gradlew testDebug
+      - android/save-gradle-cache
+  android-test:
+    executor:
+      name: android/android-machine
+      resource-class: large
+      tag: default
+    steps:
+      - checkout
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-30;google_apis;x86
 
 workflows:
-  unit-tests:
+  test:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -20,7 +36,7 @@ workflows:
               only:
                 - main
     jobs:
-      - gradle/test:
-          matrix:
-            <<: *matrix_executors
+      - unit-test
+      - android-test
+
 


### PR DESCRIPTION
## Which problem is this PR solving?

Sets up CircleCI integration for the Android SDK.

## Short description of the changes

This is a standard Android CircleCI setup according to https://circleci.com/developer/orbs/orb/circleci/android

The only change I made was adding a trigger to make it run.

## How to verify that this has the expected result

I don't know how to really test this other than to push it and see that the project/workflow shows up in CircleCI. Any other suggestions are appreciated. The `circleci` CLI says the config is "valid":

```
$ circleci config validate .circleci/config.yml
Config file at .circleci/config.yml is valid.
```

I tried to run it locally with the circleci cli, but apparently "machine" images aren't supported by the cli, and it couldn't download the image. I tried with a different image, but we'd have to do something hacky to start the emulator. So it's probably best to follow the recommended setup here.