### PR TITLE
feat: add metrics to example app

### DIFF
--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -14,6 +14,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -129,6 +130,11 @@ class Honeycomb {
 
             if (options.debug) {
                 otelRumBuilder.addSpanExporterCustomizer { OtlpJsonLoggingSpanExporter.create() }
+                otelRumBuilder.addMeterProviderCustomizer{ builder, _ ->
+                    builder.registerMetricReader(
+                        PeriodicMetricReader.builder(OtlpJsonLoggingMetricExporter.create()).build()
+                    )
+                }
             }
 
             return otelRumBuilder.build()

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -44,6 +44,11 @@ class HoneycombSmokeTest {
     }
 
     @Test
+    fun metric_works() {
+        rule.onNodeWithText("Send Metric").performClick()
+    }
+
+    @Test
     fun anrDetection_works() {
         rule.onNodeWithText("Become Unresponsive (ANR)").performClick()
     }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
@@ -19,7 +19,7 @@ class ExampleApp: Application() {
             .setApiEndpoint("http://10.0.2.2:4318")
             .setServiceName("android-test")
             .setMetricsDataset("android-test-metrics")
-            .setDebug(true)
+            .setDebug(false)
             .build()
 
         otelRum = Honeycomb.configure(this, options)

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -182,7 +182,7 @@ fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
         }
         Button(onClick = { onSendMetrics(otel) }) {
             Text(
-                text = "Send Random Metric",
+                text = "Send Metric",
             )
         }
         Button(onClick = { onANR() }) {

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -73,6 +73,14 @@ private fun onSendSpan(otelRum: OpenTelemetryRum?) {
     span?.end()
 }
 
+private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
+    val otel = otelRum?.openTelemetry
+    val meter = otel?.getMeter("@honeycombio/smoke-test")
+    var counter = meter?.counterBuilder("smoke-test.random.int")?.build()
+
+    counter?.add(Math.random().toLong())
+}
+
 private fun onANR() {
     // Occupy the main thread long enough for Android to think the app is unresponsive.
     Thread.sleep(10000)
@@ -170,6 +178,11 @@ fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
         Button(onClick = { onSendSpan(otel) }) {
             Text(
                 text = "Send Span",
+            )
+        }
+        Button(onClick = { onSendMetrics(otel) }) {
+            Text(
+                text = "Send Random Metric",
             )
         }
         Button(onClick = { onANR() }) {

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -76,7 +76,7 @@ private fun onSendSpan(otelRum: OpenTelemetryRum?) {
 private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
     val meter = otel?.getMeter("@honeycombio/smoke-test")
-    var counter = meter?.counterBuilder("smoke-test.int.metric")?.build()
+    val counter = meter?.counterBuilder("smoke-test.random.int")?.build()
 
     counter?.add(1)
 }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -76,7 +76,7 @@ private fun onSendSpan(otelRum: OpenTelemetryRum?) {
 private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
     val meter = otel?.getMeter("@honeycombio/smoke-test")
-    val counter = meter?.counterBuilder("smoke-test.random.int")?.build()
+    val counter = meter?.counterBuilder("smoke-test.metric.int")?.build()
 
     counter?.add(1)
 }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -76,9 +76,9 @@ private fun onSendSpan(otelRum: OpenTelemetryRum?) {
 private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
     val meter = otel?.getMeter("@honeycombio/smoke-test")
-    var counter = meter?.counterBuilder("smoke-test.random.int")?.build()
+    var counter = meter?.counterBuilder("smoke-test.int.metric")?.build()
 
-    counter?.add(Math.random().toLong())
+    counter?.add(1)
 }
 
 private fun onANR() {

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -19,3 +19,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [file, logging]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file, logging]

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -17,6 +17,11 @@ teardown_file() {
   assert_equal "$result" '"test-span"'
 }
 
+@test "SDK can send metrics" {
+  result=$(metric_names_for ${SMOKE_TEST_SCOPE})
+  assert_equal "$result" '"smoke-test.int.metric"'
+}
+
 @test "SDK detects ANRs" {
   result=$(unique_span_names_for "io.opentelemetry.anr")
   assert_equal "$result" '"ANR"'

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -19,7 +19,7 @@ teardown_file() {
 
 @test "SDK can send metrics" {
   result=$(metric_names_for ${SMOKE_TEST_SCOPE})
-  assert_equal "$result" '"smoke-test.int.metric"'
+  assert_equal "$result" '"smoke-test.metric.int"'
 }
 
 @test "SDK detects ANRs" {

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -30,6 +30,18 @@ spans_from_scope_named() {
 	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
 }
 
+# Metrics for a given scope
+# Arguments: $1 - scope name
+metrics_from_scope_named() {
+	spans_received | jq ".scopeMetrics[] | select(.scope.name == \"$1\").metrics[]"
+}
+
+# Metric names for a given scope
+# Arguments: $1 - scope name
+metric_names_for() {
+	metrics_from_scope_named $1 | jq '.name'
+}
+
 # All spans received
 spans_received() {
 	jq ".resourceSpans[]?" ./collector/data.json

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -30,10 +30,19 @@ spans_from_scope_named() {
 	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
 }
 
+# All spans received
+spans_received() {
+	jq ".resourceSpans[]?" ./collector/data.json
+}
+
+metrics_received() {
+  jq ".resourceMetrics[]?" ./collector/data.json
+}
+
 # Metrics for a given scope
 # Arguments: $1 - scope name
 metrics_from_scope_named() {
-	spans_received | jq ".scopeMetrics[] | select(.scope.name == \"$1\").metrics[]"
+	metrics_received | jq ".scopeMetrics[] | select(.scope.name == \"$1\").metrics[]"
 }
 
 # Metric names for a given scope
@@ -42,10 +51,6 @@ metric_names_for() {
 	metrics_from_scope_named $1 | jq '.name'
 }
 
-# All spans received
-spans_received() {
-	jq ".resourceSpans[]?" ./collector/data.json
-}
 
 # ASSERTION HELPERS
 


### PR DESCRIPTION
## Which problem is this PR solving?
This adds metrics to the example app. It also updates the collector config to accept metrics as well as updates our smoke tests to assert that metrics are sent.

It also adds a JsonMetricExporter when `debug` is true. We discovered that `debug = true` is overwriting existing exporters (ie. traces/metrics go ONLY to the console when debug is true). That will be fixed in a subsequent PR.

## How to verify that this has the expected result
Run the sample app, click the "send random metric" button, look in the collector logs:

![image](https://github.com/user-attachments/assets/f4b15e2b-2c9d-4918-b5db-5ac3263f0de8)

or turn debug on and look in the device logs:

![image](https://github.com/user-attachments/assets/ee960957-b7b2-426e-b507-0a4075071e69)

