### PR TITLE
fix: debug mode should use default exporters IN ADDITION to console exporters

### DIFF
--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -4,17 +4,13 @@ import android.app.Application
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
-import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
-import io.opentelemetry.android.instrumentation.anr.AnrDetector
 import io.opentelemetry.android.instrumentation.anr.AnrInstrumentation
-import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation
 import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingInstrumentation
-import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -22,10 +18,16 @@ import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.metrics.export.MetricExporter
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import io.opentelemetry.sdk.trace.export.SpanExporter
 import kotlin.time.toJavaDuration
 
 /** Creates an Attributes object from a String->String Map. */
@@ -42,8 +44,6 @@ private fun createAttributes(dict: Map<String, String>): Attributes {
 //
 // * DeterministicSampler.
 // * BaggageSpanProcessor.
-// * LoggingSpanExporter.
-// * LoggingMetricExporter.
 // * Debug logging.
 //
 // TODO: Add options for enabling/disabling specific instrumentation.
@@ -54,32 +54,8 @@ class Honeycomb {
          * Automatically configures OpenTelemetryRum based on values stored in the app's resources.
          */
         fun configure(app: Application, options: HoneycombOptions): OpenTelemetryRum {
-            val traceExporter = if (options.tracesProtocol == OtlpProtocol.GRPC) {
-                OtlpGrpcSpanExporter.builder()
-                    .setEndpoint(options.tracesEndpoint)
-                    .setTimeout(options.tracesTimeout.toJavaDuration())
-                    .setHeaders { options.tracesHeaders }
-                    .build()
-            } else {
-                OtlpHttpSpanExporter.builder()
-                    .setEndpoint(options.tracesEndpoint)
-                    .setTimeout(options.tracesTimeout.toJavaDuration())
-                    .setHeaders { options.tracesHeaders }
-                    .build()
-            }
-            val metricsExporter = if (options.metricsProtocol == OtlpProtocol.GRPC) {
-                OtlpGrpcMetricExporter.builder()
-                    .setEndpoint(options.metricsEndpoint)
-                    .setTimeout(options.metricsTimeout.toJavaDuration())
-                    .setHeaders { options.metricsHeaders }
-                    .build()
-            } else {
-                OtlpHttpMetricExporter.builder()
-                    .setEndpoint(options.metricsEndpoint)
-                    .setTimeout(options.metricsTimeout.toJavaDuration())
-                    .setHeaders { options.metricsHeaders }
-                    .build()
-            }
+            val traceExporter = buildSpanExporter(options)
+            val metricsExporter = buildMetricsExporter(options)
             val logsExporter = if (options.logsProtocol == OtlpProtocol.GRPC) {
                 OtlpGrpcLogRecordExporter.builder()
                     .setEndpoint(options.logsEndpoint)
@@ -110,7 +86,7 @@ class Honeycomb {
 
             val batchSpanProcessor = BatchSpanProcessor.builder(traceExporter).build()
 
-            val otelRumBuilder = OpenTelemetryRum.builder(app, rumConfig)
+            return OpenTelemetryRum.builder(app, rumConfig)
                 .setResource(resource)
                 .addSpanExporterCustomizer {
                     traceExporter
@@ -133,18 +109,84 @@ class Honeycomb {
                 .addInstrumentation(crashInstrumentation)
                 .addInstrumentation(lifecycleInstrumentation)
                 .addInstrumentation(slowRenderingInstrumentation)
+                .build()
+        }
 
-            if (options.debug) {
-                otelRumBuilder.addSpanExporterCustomizer { OtlpJsonLoggingSpanExporter.create() }
-                otelRumBuilder.addMeterProviderCustomizer{ builder, _ ->
-                    builder.registerMetricReader(
-                        PeriodicMetricReader.builder(OtlpJsonLoggingMetricExporter.create()).build()
-                    )
-                }
+        private fun buildSpanExporter(options: HoneycombOptions): SpanExporter {
+            val traceExporter = if (options.tracesProtocol == OtlpProtocol.GRPC) {
+                OtlpGrpcSpanExporter.builder()
+                    .setEndpoint(options.tracesEndpoint)
+                    .setTimeout(options.tracesTimeout.toJavaDuration())
+                    .setHeaders { options.tracesHeaders }
+                    .build()
+            } else {
+                OtlpHttpSpanExporter.builder()
+                    .setEndpoint(options.tracesEndpoint)
+                    .setTimeout(options.tracesTimeout.toJavaDuration())
+                    .setHeaders { options.tracesHeaders }
+                    .build()
             }
 
-            return otelRumBuilder.build()
+            if (options.debug) {
+                return SpanExporter.composite(traceExporter, OtlpJsonLoggingSpanExporter.create())
+            }
+            return traceExporter;
+        }
+
+        private fun buildMetricsExporter(options: HoneycombOptions): MetricExporter {
+            val metricsExporter = if (options.metricsProtocol == OtlpProtocol.GRPC) {
+                OtlpGrpcMetricExporter.builder()
+                    .setEndpoint(options.metricsEndpoint)
+                    .setTimeout(options.metricsTimeout.toJavaDuration())
+                    .setHeaders { options.metricsHeaders }
+                    .build()
+            } else {
+                OtlpHttpMetricExporter.builder()
+                    .setEndpoint(options.metricsEndpoint)
+                    .setTimeout(options.metricsTimeout.toJavaDuration())
+                    .setHeaders { options.metricsHeaders }
+                    .build()
+            }
+
+            if (options.debug) {
+                return CompositeMetricExporter(metricsExporter, OtlpJsonLoggingMetricExporter.create())
+            }
+            return metricsExporter;
+        }
+    }
+
+    private class CompositeMetricExporter(vararg val exporters: MetricExporter): MetricExporter {
+        override fun getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality {
+            return try {
+                exporters.first().getAggregationTemporality(instrumentType);
+            } catch (e: NoSuchElementException) {
+                // doesn't really matter
+                AggregationTemporality.DELTA;
+            }
+        }
+
+        override fun export(metrics: MutableCollection<MetricData>): CompletableResultCode {
+            val codes = ArrayList<CompletableResultCode>()
+            for (exporter in exporters) {
+                codes.add(exporter.export(metrics))
+            }
+            return CompletableResultCode.ofAll(codes)
+        }
+
+        override fun flush(): CompletableResultCode {
+            val codes = ArrayList<CompletableResultCode>()
+            for (exporter in exporters) {
+                codes.add(exporter.flush())
+            }
+            return CompletableResultCode.ofAll(codes)
+        }
+
+        override fun shutdown(): CompletableResultCode {
+            val codes = ArrayList<CompletableResultCode>()
+            for (exporter in exporters) {
+                codes.add(exporter.shutdown())
+            }
+            return CompletableResultCode.ofAll(codes)
         }
     }
 }
-

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
@@ -19,7 +19,7 @@ class ExampleApp: Application() {
             .setApiEndpoint("http://10.0.2.2:4318")
             .setServiceName("android-test")
             .setMetricsDataset("android-test-metrics")
-            .setDebug(false)
+            .setDebug(true)
             .build()
 
         otelRum = Honeycomb.configure(this, options)


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a bug introduced in #10 and compounded in #11 : `debug = true` was sending metrics/traces to console ONLY, not console AND whatever other exporter we had
 
## Short description of the changes
For traces, we can use otel's CompositeTraceExporter
For metrics, I had to write my own CompositeMetricExporter because OTEL doesn't supply one. I shoved it as a private inner class in the main Honeycomb class but I'm open to pulling it out into it's own thing if that's what we want.

## How to verify that this has the expected result
Run the example app, verify that metrics + traces appear in BOTH the collector logs and the editor stdout