### PR TITLE
feat: Add okhttp instrumentation to example app & smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,6 @@ jobs:
       - android/run-tests:
           test-command: ./gradlew testDebug
       - android/save-gradle-cache
-  android_test:
-    executor:
-      name: android/android-machine
-      resource-class: large
-      tag: default
-    steps:
-      - checkout
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-30;google_apis;x86
   smoke_test:
     executor:
       name: android/android-machine
@@ -98,8 +89,6 @@ workflows:
     jobs:
       - unit_test:
           <<: *filters_always
-      - android_test:
-          <<: *filters_always
       - smoke_test:
           <<: *filters_always
       - publish_maven:
@@ -108,7 +97,6 @@ workflows:
             - java_beeline
           requires:
             - unit_test
-            - android_test
             - smoke_test
   nightly:
     triggers:
@@ -120,5 +108,4 @@ workflows:
                 - main
     jobs:
       - unit_test
-      - android_test
       - smoke_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             which bats
             bats --version
       - run:
-          name: "Start Collector"
+          name: "Start Collector & Mock Server"
           command: make smoke-docker
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ smoke-docker: smoke-tests/collector/data.json
 	@echo ""
 	@echo "+++ Spinning up the smokers."
 	@echo ""
-	docker compose up --build collector --detach
+	docker compose up --build collector --build mock-server --detach
 
 android-emulator:
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -119,3 +119,9 @@ A trace is emitted whenever a frame is rendered too slowly, according to Android
 * attributes:
   * `activity.name` - the fully-qualified name of the activity, such as `"io.honeycomb.opentelemetry.android.example/.MainActivity"`
 
+### Network Instrumentation
+Network instrumentation is not included by default but can be configured on top of this distro. We test with the following OpenTelemetry instrumentation packages:
+
+* [`io.opentelemetry.android:okhttp-3.0`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/okhttp/okhttp-3.0)
+
+Configuration of each of these packages is described in their respective READMEs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - './smoke-tests/collector:/var/lib'
     ports:
       - '4318:4318'
+  mock-server:
+    image: mockserver/mockserver
+    volumes:
+      - './smoke-tests/mock-server:/config'
+    ports:
+      - '1080:1080'

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    id("net.bytebuddy.byte-buddy-gradle-plugin") version("1.15.5")
 }
 
 android {
@@ -88,4 +89,8 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation(libs.okhttp)
+    implementation("io.opentelemetry.android:okhttp-3.0-library:0.7.0-alpha")
+    byteBuddy("io.opentelemetry.android:okhttp-3.0-agent:0.7.0-alpha")
 }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -91,6 +91,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     implementation(libs.okhttp)
-    implementation("io.opentelemetry.android:okhttp-3.0-library:0.7.0-alpha")
-    byteBuddy("io.opentelemetry.android:okhttp-3.0-agent:0.7.0-alpha")
+    implementation(libs.okhttp.library)
+    byteBuddy(libs.okhttp.agent)
 }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -53,7 +53,7 @@ class HoneycombSmokeTest {
     fun network_instrumentation_works() {
         rule.onNodeWithText("Make a Network Request").performClick()
 
-        rule.waitUntil {
+        rule.waitUntil(5000) {
             rule.onNodeWithText("Network Request Succeeded", true).isDisplayed()
         }
     }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -1,5 +1,6 @@
 package io.honeycomb.opentelemetry.android.example
 
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -51,6 +52,10 @@ class HoneycombSmokeTest {
     @Test
     fun network_instrumentation_works() {
         rule.onNodeWithText("Make a Network Request").performClick()
+
+        rule.waitUntil {
+            rule.onNodeWithText("Network Request Succeeded", true).isDisplayed()
+        }
     }
 
     @Test

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -49,6 +49,11 @@ class HoneycombSmokeTest {
     }
 
     @Test
+    fun network_instrumentation_works() {
+        rule.onNodeWithText("Make a Network Request").performClick()
+    }
+
+    @Test
     fun anrDetection_works() {
         rule.onNodeWithText("Become Unresponsive (ANR)").performClick()
     }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -26,8 +26,10 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -39,8 +41,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import io.opentelemetry.android.OpenTelemetryRum
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Headers
@@ -91,20 +91,24 @@ private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
     counter?.add(1)
 }
 
-private fun onSendNetworkRequest(otelRum: OpenTelemetryRum?) {
+private fun onSendNetworkRequest(setResponse: (str: String) -> Unit) {
     Log.w(TAG, "making network request")
+    setResponse("loading...")
 
     val client = OkHttpClient.Builder().build()
     val request = Request.Builder()
-        .url("https://icanhazdadjoke.com/")
+        .url("http://10.0.2.2:1080/simple-api")
         .headers(Headers.headersOf("content-type", "application/json", "accept", "application/json"))
         .build()
     val callback = object : Callback {
         override fun onFailure(call: Call, e: IOException) {
             Log.w(TAG, "OkHttp error response: $e")
+            setResponse("error: ${e.message}")
         }
         override fun onResponse(call: Call, response: Response) {
-            Log.w(TAG, "OkHttp response: ${response.code}: ${response.message}, ${response.body?.string()}")
+            val body = response.body?.string()
+            Log.w(TAG, "OkHttp response: ${response.code}: ${response.message}, $body")
+            setResponse("Network Request Succeeded")
             response.close()
         }
     }
@@ -130,6 +134,8 @@ enum class AnimationSpeed(val sleepTime: Long) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
+    val apiStatus = remember { mutableStateOf("") }
+
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -157,28 +163,29 @@ fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
         var animationSpeed by remember {
             mutableStateOf(AnimationSpeed.NORMAL)
         }
-        Spacer(modifier = Modifier
-            .height(100.dp)
-            .width(100.dp)
-            .drawBehind {
-                // This is what makes it slow.
-                if (animationSpeed.sleepTime > 0) {
-                    Thread.sleep(animationSpeed.sleepTime)
-                }
-                drawCircle(color = Color.Gray)
-                inset(5.dp.toPx()) {
-                    drawCircle(color = Color.Yellow)
-                    val top = Offset(center.x, 0.0f)
-                    rotate(degrees = angle.value) {
-                        drawLine(
-                            color = Color.Gray,
-                            start = top,
-                            end = center,
-                            strokeWidth = 5.dp.toPx()
-                        )
+        Spacer(
+            modifier = Modifier
+                .height(100.dp)
+                .width(100.dp)
+                .drawBehind {
+                    // This is what makes it slow.
+                    if (animationSpeed.sleepTime > 0) {
+                        Thread.sleep(animationSpeed.sleepTime)
                     }
-                }
-            },
+                    drawCircle(color = Color.Gray)
+                    inset(5.dp.toPx()) {
+                        drawCircle(color = Color.Yellow)
+                        val top = Offset(center.x, 0.0f)
+                        rotate(degrees = angle.value) {
+                            drawLine(
+                                color = Color.Gray,
+                                start = top,
+                                end = center,
+                                strokeWidth = 5.dp.toPx()
+                            )
+                        }
+                    }
+                },
         )
         SingleChoiceSegmentedButtonRow {
             SegmentedButton(
@@ -225,11 +232,14 @@ fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
                 text = "Crash",
             )
         }
-        Button(onClick = { onSendNetworkRequest(otel) }) {
+        Button(onClick = { onSendNetworkRequest { res -> apiStatus.value = res } }) {
             Text(
                 text = "Make a Network Request",
             )
         }
+        Text(
+            text = apiStatus.value,
+        )
     }
 }
 

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -49,7 +49,7 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
 
-val TAG = "mhaddara"
+val TAG = "example-app"
 
 /**
  * An activity with various UI elements that cause telemetry to be emitted.

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -49,7 +49,7 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
 
-val TAG = "example-app"
+val TAG = "MainActivity"
 
 /**
  * An activity with various UI elements that cause telemetry to be emitted.
@@ -134,7 +134,7 @@ enum class AnimationSpeed(val sleepTime: Long) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
-    val apiStatus = remember { mutableStateOf("") }
+    val networkRequestStatus = remember { mutableStateOf("") }
 
     Column(
         verticalArrangement = Arrangement.Center,
@@ -232,13 +232,13 @@ fun Playground(otel: OpenTelemetryRum?, modifier: Modifier = Modifier) {
                 text = "Crash",
             )
         }
-        Button(onClick = { onSendNetworkRequest { res -> apiStatus.value = res } }) {
+        Button(onClick = { onSendNetworkRequest { res -> networkRequestStatus.value = res } }) {
             Text(
                 text = "Make a Network Request",
             )
         }
         Text(
-            text = apiStatus.value,
+            text = networkRequestStatus.value,
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ opentelemetry = "1.38.0"
 opentelemetryAndroid = "0.7.0-alpha"
 opentelemetryInstrumentation = "2.7.0"
 publish = "1.3.0"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -44,6 +45,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-library = { module = "io.opentelemetry.android:okhttp-3.0-library", version.ref = "opentelemetryAndroid" }
+okhttp-agent = { module = "io.opentelemetry.android:okhttp-3.0-agent", version.ref = "opentelemetryAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/smoke-tests/mock-server/README.md
+++ b/smoke-tests/mock-server/README.md
@@ -1,0 +1,5 @@
+# mock-server
+
+We use [mock-server](https://www.mock-server.com) to provide simple API endpoints we can hit from our example app and smoke tests.
+
+Endpoints and their responses are configured in `mock-server.json`

--- a/smoke-tests/mock-server/mock-server.json
+++ b/smoke-tests/mock-server/mock-server.json
@@ -1,0 +1,10 @@
+[
+  {
+    "httpRequest": {
+      "path": "/simple-api"
+    },
+    "httpResponse": {
+      "body": "this is the api response"
+    }
+  }
+]

--- a/smoke-tests/mock-server/mockserver.properties
+++ b/smoke-tests/mock-server/mockserver.properties
@@ -1,0 +1,1 @@
+mockserver.initializationJsonPath=/config/mock-server.json

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -33,3 +33,8 @@ teardown_file() {
 "slowRenders"'
 }
 
+@test "Network auto-instrumentation sends spans" {
+  result=$(span_names_for "io.opentelemetry.okhttp-3.0")
+  assert_equal "$result" '"GET"'
+}
+


### PR DESCRIPTION
## Which problem is this PR solving?
Adds Okhttp instrumentation to example app

## Short description of the changes
Also adds a smoke test that verifies the instrumentation sends out the correct spans

## How to verify that this has the expected result
- [x] Run the example app and look at the logs
- [x] Smoke tests pass