### PR TITLE
feat: add render instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,35 @@ These events may have the following attributes.
 ## Manual Instrumentation
 
 ### Android Compose
-Wrap your SwiftUI views with `HoneycombInstrumentedComposable(name: String, otelRum: OpenTelemetry)`, like so:
+#### Setup
+Initialize the `Honeycomb` sdk, and then wrap your entire app in a `CompositionLocalProvider` that provides `LocalOpenTelemetryRum`, as so:
 
+```kotlin
+import io.honeycomb.opentelemetry.android.LocalOpenTelemetryRum
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val app = application as ExampleApp
+        val otelRum = app.otelRum
+
+        setContent {
+            CompositionLocalProvider(LocalOpenTelemetryRum provides otelRum) {
+                // app content
+            }
+        }
+    }
+}
 ```
+
+#### Usage
+Wrap your SwiftUI views with `HoneycombInstrumentedComposable(name: String)`, like so:
+
+```kotlin
 @Composable
 private fun MyComposable() {
-    HoneycombInstrumentedComposable("main view", openTelemetry) {
+    HoneycombInstrumentedComposable("main view") {
         // ...
     }
 }

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Specifically, it will emit 2 kinds of span for each composable that is wrapped:
 
 `View Render` spans encompass the entire rendering process, from initialization to appearing on screen. They include the following attributes:
 - `view.name` (string): the name passed to `HoneycombInstrumentedComposable`
-- `view.renderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedComposable`
-- `view.totalDuration` (double): amount of time from when the contents of `HoneycombInstrumentedComposable` start initializing to when the contents appear on screen
+- `view.renderDuration` (double): amount of time in seconds to spent initializing the contents of `HoneycombInstrumentedComposable`
+- `view.totalDuration` (double): amount of time in seconds from when the contents of `HoneycombInstrumentedComposable` start initializing to when the contents appear on screen
 
 `View Body` spans encompass just the contents of the `HoneycombInstrumentedView`, and include the following attributes:
 - `view.name` (string): the name passed to `HoneycombInstrumentedComposable`

--- a/README.md
+++ b/README.md
@@ -146,3 +146,28 @@ These events may have the following attributes.
 * `view.id.package` - The package for the XML ID of the view.
 * `view.name` - The "best" available name of the view, given the other identifiers. Usually the same as `view.id.entry`.
 
+## Manual Instrumentation
+
+### Android Compose
+Wrap your SwiftUI views with `HoneycombInstrumentedComposable(name: String, otelRum: OpenTelemetry)`, like so:
+
+```
+@Composable
+private fun MyComposable() {
+    HoneycombInstrumentedComposable("main view", openTelemetry) {
+        // ...
+    }
+}
+```
+
+This will measure and emit instrumentation for your Composable's render times, ex:
+
+Specifically, it will emit 2 kinds of span for each composable that is wrapped:
+
+`View Render` spans encompass the entire rendering process, from initialization to appearing on screen. They include the following attributes:
+- `view.name` (string): the name passed to `HoneycombInstrumentedComposable`
+- `view.renderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedComposable`
+- `view.totalDuration` (double): amount of time from when the contents of `HoneycombInstrumentedComposable` start initializing to when the contents appear on screen
+
+`View Body` spans encompass just the contents of the `HoneycombInstrumentedView`, and include the following attributes:
+- `view.name` (string): the name passed to `HoneycombInstrumentedComposable`

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -25,6 +25,7 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        compose = true
     }
     buildTypes {
         release {
@@ -39,6 +40,9 @@ android {
         isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
     }
     kotlinOptions {
         jvmTarget = "1.8"
@@ -57,6 +61,10 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.runtime.android)
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+
     // This is required by opentelemetry-android.
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.runtime.android)
+    implementation(libs.androidx.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
 

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
@@ -9,7 +9,7 @@ import java.time.Instant
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource.Monotonic.markNow
 
-private const val TAG = "HNY OTel Compose" // max 23 characters :sob:
+private const val TAG = "HoneycombInstrumentedCo" // max 23 characters :sob:
 
 /**
  * Heavily inspired by https://github.com/theapache64/boil/blob/master/files/LogComposition.kt

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
@@ -1,0 +1,50 @@
+package io.honeycomb.opentelemetry.android
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import io.opentelemetry.api.OpenTelemetry
+import java.time.Instant
+import kotlin.time.TimeSource.Monotonic.markNow
+
+/**
+ * Heavily inspired by https://github.com/theapache64/boil/blob/master/files/LogComposition.kt
+ */
+@Composable
+fun HoneycombInstrumentedComposable(
+    name: String,
+    otelRum: OpenTelemetry,
+    composable: @Composable (() -> Unit),
+) {
+    val tracer = otelRum.tracerProvider.tracerBuilder("io.honeycomb.render-instrumentation").build()
+    val span =
+        tracer
+            .spanBuilder("View Render")
+            .setAttribute("view.name", name)
+            .startSpan()
+
+    span.makeCurrent().use {
+        val bodySpan =
+            tracer
+                .spanBuilder("View Body")
+                .setAttribute("view.name", name)
+                .startSpan()
+
+        bodySpan.makeCurrent().use {
+            val start = markNow()
+            composable()
+            val endTime = Instant.now()
+
+            val bodyDuration = start.elapsedNow()
+            // bodyDuration is in seconds
+            // calling duration.inWholeSeconds would lose precision
+            span.setAttribute("view.renderDuration", bodyDuration.inWholeMicroseconds / 1_000_000.toDouble())
+
+            SideEffect {
+                bodySpan.end(endTime)
+                val renderDuration = start.elapsedNow()
+                span.setAttribute("view.totalDuration", renderDuration.inWholeMicroseconds / 1_000_000.toDouble())
+                span.end()
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombInstrumentedComposable.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import io.opentelemetry.api.OpenTelemetry
 import java.time.Instant
+import kotlin.time.DurationUnit
 import kotlin.time.TimeSource.Monotonic.markNow
 
 /**
@@ -37,12 +38,12 @@ fun HoneycombInstrumentedComposable(
             val bodyDuration = start.elapsedNow()
             // bodyDuration is in seconds
             // calling duration.inWholeSeconds would lose precision
-            span.setAttribute("view.renderDuration", bodyDuration.inWholeMicroseconds / 1_000_000.toDouble())
+            span.setAttribute("view.renderDuration", bodyDuration.toDouble(DurationUnit.SECONDS))
 
             SideEffect {
                 bodySpan.end(endTime)
                 val renderDuration = start.elapsedNow()
-                span.setAttribute("view.totalDuration", renderDuration.inWholeMicroseconds / 1_000_000.toDouble())
+                span.setAttribute("view.totalDuration", renderDuration.toDouble(DurationUnit.SECONDS))
                 span.end()
             }
         }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -1,7 +1,10 @@
 package io.honeycomb.opentelemetry.android.example
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.text.intl.Locale
@@ -103,5 +106,19 @@ class HoneycombSmokeTest {
 
         val backButton: UiObject2? = device.findObject(buttonSelector("Back"))
         backButton!!.clickAndWait(Until.newWindow(), 1000)
+    }
+
+    @Test
+    fun renderInstrumentation_works() {
+        rule.onNodeWithText("Render").performClick()
+        rule.onNodeWithTag("slow_render_switch").performClick()
+
+        rule.waitUntil(5000) {
+            rule.onAllNodesWithText("slow text", true).assertCountEquals(5)
+
+            true
+        }
+
+        rule.onNodeWithText("Core").performClick()
     }
 }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -49,7 +49,7 @@ enum class PlaygroundTab(
     CORE("Core", Icons.Outlined.Home, Icons.Filled.Home),
     UI("UI", Icons.Outlined.Palette, Icons.Filled.Palette),
     NETWORK("Network", Icons.Outlined.Language, Icons.Filled.Language),
-    VIEW_INSTRUMENTATION("Render", Icons.Outlined.Straighten, Icons.Filled.Straighten)
+    VIEW_INSTRUMENTATION("Render", Icons.Outlined.Straighten, Icons.Filled.Straighten),
 }
 
 /**

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -37,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.honeycomb.opentelemetry.android.LocalOpenTelemetryRum
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import io.opentelemetry.android.OpenTelemetryRum
 
@@ -54,8 +54,6 @@ enum class PlaygroundTab(
     VIEW_INSTRUMENTATION("Render", Icons.Outlined.Straighten, Icons.Filled.Straighten),
 }
 
-val LocalOtelComposition = compositionLocalOf<OpenTelemetryRum?> { null }
-
 /**
  * An activity with various UI elements that cause telemetry to be emitted.
  */
@@ -70,7 +68,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val currentTab = remember { mutableStateOf(PlaygroundTab.CORE) }
 
-            CompositionLocalProvider(LocalOtelComposition provides otelRum) {
+            CompositionLocalProvider(LocalOpenTelemetryRum provides otelRum) {
                 HoneycombOpenTelemetryAndroidTheme {
                     Scaffold(
                         modifier = Modifier.fillMaxSize(),

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -26,8 +26,10 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -52,6 +54,8 @@ enum class PlaygroundTab(
     VIEW_INSTRUMENTATION("Render", Icons.Outlined.Straighten, Icons.Filled.Straighten),
 }
 
+val LocalOtelComposition = compositionLocalOf<OpenTelemetryRum?> { null }
+
 /**
  * An activity with various UI elements that cause telemetry to be emitted.
  */
@@ -66,16 +70,18 @@ class MainActivity : ComponentActivity() {
         setContent {
             val currentTab = remember { mutableStateOf(PlaygroundTab.CORE) }
 
-            HoneycombOpenTelemetryAndroidTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    bottomBar = { NavBar(currentTab) },
-                ) { innerPadding ->
-                    Playground(
-                        otelRum,
-                        currentTab,
-                        modifier = Modifier.padding(innerPadding),
-                    )
+            CompositionLocalProvider(LocalOtelComposition provides otelRum) {
+                HoneycombOpenTelemetryAndroidTheme {
+                    Scaffold(
+                        modifier = Modifier.fillMaxSize(),
+                        bottomBar = { NavBar(currentTab) },
+                    ) { innerPadding ->
+                        Playground(
+                            otelRum,
+                            currentTab,
+                            modifier = Modifier.padding(innerPadding),
+                        )
+                    }
                 }
             }
         }
@@ -92,7 +98,10 @@ fun Playground(
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.fillMaxSize().padding(20.dp),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(20.dp),
     ) {
         Text(
             text =

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/MainActivity.kt
@@ -14,9 +14,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Straighten
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material.icons.outlined.Straighten
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -47,6 +49,7 @@ enum class PlaygroundTab(
     CORE("Core", Icons.Outlined.Home, Icons.Filled.Home),
     UI("UI", Icons.Outlined.Palette, Icons.Filled.Palette),
     NETWORK("Network", Icons.Outlined.Language, Icons.Filled.Language),
+    VIEW_INSTRUMENTATION("Render", Icons.Outlined.Straighten, Icons.Filled.Straighten)
 }
 
 /**
@@ -103,11 +106,14 @@ fun Playground(
             PlaygroundTab.CORE -> {
                 CorePlayground(otel)
             }
-            PlaygroundTab.UI -> {
-                UIPlayground()
-            }
             PlaygroundTab.NETWORK -> {
                 NetworkPlayground()
+            }
+            PlaygroundTab.VIEW_INSTRUMENTATION -> {
+                ViewInstrumentationPlayground()
+            }
+            PlaygroundTab.UI -> {
+                UIPlayground()
             }
         }
     }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
@@ -1,13 +1,9 @@
 package io.honeycomb.opentelemetry.android.example
 
-import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -18,9 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -33,14 +27,17 @@ private fun NestedExpensiveView(delayMs: Long) {
 }
 
 @Composable
-private fun DelayedSlider(delay: Long, onValueChange: (Long) -> Unit) {
+private fun DelayedSlider(
+    delay: Long,
+    onValueChange: (Long) -> Unit,
+) {
     val (sliderDelay, setSliderDelay) = remember { mutableFloatStateOf(delay.toFloat()) }
     Slider(
         value = sliderDelay,
         onValueChange = setSliderDelay,
         onValueChangeFinished = { onValueChange(sliderDelay.toLong()) },
         valueRange = 0f..4000f,
-        steps = 7
+        steps = 7,
     )
 }
 
@@ -73,8 +70,8 @@ internal fun ViewInstrumentationPlayground() {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
-        ){
+            modifier = Modifier.fillMaxWidth(),
+        ) {
             Text(text = "enable slow render")
             Switch(checked = enabled, onCheckedChange = setEnabled)
         }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import io.honeycomb.opentelemetry.android.HoneycombInstrumentedComposable
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
 
 private const val TAG = "ViewInstrumentation"
 

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import java.math.BigDecimal
@@ -34,7 +35,7 @@ private inline fun HoneycombInstrumentedComposable(
     name: String,
     composable: @Composable (() -> Unit),
 ) {
-    val tracer = LocalOtelComposition.current!!.openTelemetry.tracerProvider.tracerBuilder("ViewInstrumentationPlayground").build()
+    val tracer = LocalOtelComposition.current!!.openTelemetry.tracerProvider.tracerBuilder("io.honeycomb.render-instrumentation").build()
     val span =
         tracer
             .spanBuilder("View Render")
@@ -142,7 +143,11 @@ internal fun ViewInstrumentationPlayground() {
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(text = "enable slow render")
-            Switch(checked = enabled, onCheckedChange = setEnabled)
+            Switch(
+                checked = enabled,
+                onCheckedChange = setEnabled,
+                modifier = Modifier.testTag("slow_render_switch")
+            )
         }
         if (enabled) {
             ExpensiveView()

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
@@ -27,7 +27,7 @@ private const val TAG = "ViewInstrumentation"
 @Composable
 private fun NestedExpensiveView(delay: Duration) {
     Row {
-        HoneycombInstrumentedComposable("nested expensive text", LocalOtelComposition.current!!.openTelemetry) {
+        HoneycombInstrumentedComposable("nested expensive text") {
             Text(text = timeConsumingCalculation(delay))
         }
     }
@@ -52,7 +52,7 @@ private fun DelayedSlider(
 private fun ExpensiveView() {
     val (delay, setDelay) = remember { mutableStateOf(1000L.milliseconds) }
 
-    HoneycombInstrumentedComposable("main view", LocalOtelComposition.current!!.openTelemetry) {
+    HoneycombInstrumentedComposable("main view") {
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -60,23 +60,23 @@ private fun ExpensiveView() {
         ) {
             DelayedSlider(delay = delay.toLong(DurationUnit.MILLISECONDS), onValueChange = setDelay)
 
-            HoneycombInstrumentedComposable("expensive text 1", LocalOtelComposition.current!!.openTelemetry) {
+            HoneycombInstrumentedComposable("expensive text 1") {
                 Text(text = timeConsumingCalculation(delay))
             }
 
-            HoneycombInstrumentedComposable("expensive text 2", LocalOtelComposition.current!!.openTelemetry) {
+            HoneycombInstrumentedComposable("expensive text 2") {
                 Text(text = timeConsumingCalculation(delay))
             }
 
-            HoneycombInstrumentedComposable("expensive text 3", LocalOtelComposition.current!!.openTelemetry) {
+            HoneycombInstrumentedComposable("expensive text 3") {
                 Text(text = timeConsumingCalculation(delay))
             }
 
-            HoneycombInstrumentedComposable("nested expensive view", LocalOtelComposition.current!!.openTelemetry) {
+            HoneycombInstrumentedComposable("nested expensive view") {
                 NestedExpensiveView(delay = delay)
             }
 
-            HoneycombInstrumentedComposable("expensive text 4", LocalOtelComposition.current!!.openTelemetry) {
+            HoneycombInstrumentedComposable("expensive text 4") {
                 Text(text = timeConsumingCalculation(delay))
             }
         }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ViewInstrumentationPlayground.kt
@@ -1,0 +1,99 @@
+package io.honeycomb.opentelemetry.android.example
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Composable
+private fun NestedExpensiveView(delayMs: Long) {
+    Row {
+        Text(text = timeConsumingCalculation(delayMs))
+    }
+}
+
+@Composable
+private fun DelayedSlider(delay: Long, onValueChange: (Long) -> Unit) {
+    val (sliderDelay, setSliderDelay) = remember { mutableFloatStateOf(delay.toFloat()) }
+    Slider(
+        value = sliderDelay,
+        onValueChange = setSliderDelay,
+        onValueChangeFinished = { onValueChange(sliderDelay.toLong()) },
+        valueRange = 0f..4000f,
+        steps = 7
+    )
+}
+
+@Composable
+private fun ExpensiveView() {
+    val (delay, setDelay) = remember { mutableLongStateOf(1000L) }
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        DelayedSlider(delay = delay, onValueChange = setDelay)
+        Text(text = timeConsumingCalculation(delay))
+        Text(text = timeConsumingCalculation(delay))
+        Text(text = timeConsumingCalculation(delay))
+        NestedExpensiveView(delayMs = delay)
+        Text(text = timeConsumingCalculation(delay))
+    }
+}
+
+@Composable
+internal fun ViewInstrumentationPlayground() {
+    val (enabled, setEnabled) = remember { mutableStateOf(false) }
+
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ){
+            Text(text = "enable slow render")
+            Switch(checked = enabled, onCheckedChange = setEnabled)
+        }
+        if (enabled) {
+            ExpensiveView()
+        }
+    }
+}
+
+private fun timeConsumingCalculation(delayMs: Long): String {
+    println("starting time consuming calculation")
+    Thread.sleep(delayMs)
+    return "slow text: ${BigDecimal.valueOf(delayMs / 1000).setScale(2, RoundingMode.HALF_UP)} seconds"
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ViewInstrumentationPlaygroundPreview() {
+    HoneycombOpenTelemetryAndroidTheme {
+        ViewInstrumentationPlayground()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ opentelemetryInstrumentation = "2.9.0"
 publish = "1.3.0"
 spotless = "6.25.0"
 uiautomator = "2.4.0-alpha01"
+runtimeAndroid = "1.7.6"
 
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
@@ -66,6 +67,7 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref
 opentelemetry-exporter-logging-otlp = { module = "io.opentelemetry:opentelemetry-exporter-logging-otlp", version.ref = "opentelemetry" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry"  }
 opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api", version.ref = "opentelemetryInstrumentation"  }
+androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ appcompat = "1.7.0"
 autoService = "1.1.1"
 bytebuddy = "1.15.5"
 composeBom = "2024.04.01"
+composeRuntime = "1.7.6"
 constraintlayout = "2.1.4"
 coreKtx = "1.13.1"
 desugarLibs = "2.1.2"
@@ -25,7 +26,6 @@ opentelemetryInstrumentation = "2.9.0"
 publish = "1.3.0"
 spotless = "6.25.0"
 uiautomator = "2.4.0-alpha01"
-runtimeAndroid = "1.7.6"
 
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
@@ -40,6 +40,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-runtime-compose = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "composeRuntime" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
@@ -67,7 +68,6 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref
 opentelemetry-exporter-logging-otlp = { module = "io.opentelemetry:opentelemetry-exporter-logging-otlp", version.ref = "opentelemetry" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry"  }
 opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api", version.ref = "opentelemetryInstrumentation"  }
-androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -79,10 +79,17 @@ teardown_file() {
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c | xargs echo -n)
-  assert_equal "$result" '7 View Body 7 View Render'
+  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c | tr -s ' ')
+  assert_equal "$result" ' 7 "View Body"
+ 7 "View Render"'
 
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort | xargs echo -n)
-  assert_equal "$total_duration" 'expensive text 1 expensive text 2 expensive text 3 expensive text 4 main view nested expensive text nested expensive view'
+  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort | tr -s ' ')
+  assert_equal "$total_duration" '"expensive text 1"
+"expensive text 2"
+"expensive text 3"
+"expensive text 4"
+"main view"
+"nested expensive text"
+"nested expensive view"'
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -79,17 +79,10 @@ teardown_file() {
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c)
-  assert_equal "$result" '   7 "View Body"
-   7 "View Render"'
+  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c | xargs echo -n)
+  assert_equal "$result" '7 View Body 7 View Render'
 
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort)
-  assert_equal "$total_duration" '"expensive text 1"
-"expensive text 2"
-"expensive text 3"
-"expensive text 4"
-"main view"
-"nested expensive text"
-"nested expensive view"'
+  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort | xargs echo -n)
+  assert_equal "$total_duration" 'expensive text 1 expensive text 2 expensive text 3 expensive text 4 main view nested expensive text nested expensive view'
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -77,3 +77,19 @@ teardown_file() {
     assert_equal "$entry" '"example_button"'
 }
 
+@test "Render Instrumentation attributes are correct" {
+  # we got the spans we expect
+  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c)
+  assert_equal "$result" '   7 "View Body"
+   7 "View Render"'
+
+  # the View Render spans are tracking the views we expect
+  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort)
+  assert_equal "$total_duration" '"expensive text 1"
+"expensive text 2"
+"expensive text 3"
+"expensive text 4"
+"main view"
+"nested expensive text"
+"nested expensive view"'
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Adds manual instrumentation for rendering times of Composables in Jetpack Compose

## Short description of the changes
heavily inspired by https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/20


Multiple re-renders do get nested under a single "Created" Span, but otherwise the spans look identical to the iOS spans:

![image](https://github.com/user-attachments/assets/50460236-9649-4264-b457-b4be9d1eca62)

## How to verify that this has the expected result
- [x] traces appear in honeycomb with the correct values (see screenshot above)
- [x] smoke tests