### PR TITLE
feat: Implement touch auto-instrumentation on XML-based TextViews

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The following auto-instrumentation libraries are automatically included:
 * [`io.opentelemetry.android:instrumentation-crash`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/crash)
 * [`io.opentelemetry.android:instrumentation-slowrendering`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/slowrendering)
 
+The following additional auto-instrumentation is implemented in this library:
+* UI interaction in XML-based Activities.
+
 ### Activity Lifecycle Instrumentation
 
 A trace is emitted before, during, and after each stage of the [Android Activity Lifecycle](https://developer.android.com/guide/components/activities/activity-lifecycle).
@@ -125,3 +128,21 @@ Network instrumentation is not included by default but can be configured on top 
 * [`io.opentelemetry.android:okhttp-3.0`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/okhttp/okhttp-3.0)
 
 Configuration of each of these packages is described in their respective READMEs.
+
+### UI Interaction Instrumentation
+
+Various touch events are instrumented for `TextView` fields, such as:
+* `Touch Began` - A touch started
+* `Touch Ended` - A touch ended
+* `click` - A "tap"
+
+These events may have the following attributes.
+* `view.class` - e.g. `"android.widget.Button"`
+* `view.accessibilityClassName` - The [`accessibilityClassName`](https://developer.android.com/reference/android/widget/TextView#getAccessibilityClassName()) for the view.
+   Usually the same as `view.class`.
+* `view.text` - The text of the `TextView`.
+* `view.id` - The XML ID of the view element, as an integer.
+* `view.id.entry` - The text form of the XML ID of the view element.
+* `view.id.package` - The package for the XML ID of the view.
+* `view.name` - The "best" available name of the view, given the other identifiers. Usually the same as `view.id.entry`.
+

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.auto.service.annotations)
     implementation(libs.instrumentation.activity)
     implementation(libs.instrumentation.anr)
     implementation(libs.instrumentation.crash)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -1,6 +1,25 @@
 package io.honeycomb.opentelemetry.android
 
+import android.app.Activity
 import android.app.Application
+import android.graphics.Rect
+import android.os.Build
+import android.os.Bundle
+import android.view.ActionMode
+import android.view.GestureDetector
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.SearchEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.view.accessibility.AccessibilityEvent
+import android.widget.TextView
+import androidx.core.view.children
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
@@ -28,6 +47,8 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import kotlin.math.floor
+import kotlin.math.roundToInt
 import kotlin.time.toJavaDuration
 
 /** Creates an Attributes object from a String->String Map. */
@@ -82,6 +103,7 @@ class Honeycomb {
             val crashInstrumentation = CrashReporterInstrumentation()
             val lifecycleInstrumentation = ActivityLifecycleInstrumentation()
             val slowRenderingInstrumentation = SlowRenderingInstrumentation()
+            val windowInstrumentation = WindowInstrumentation()
 
             // Normally, uncaught exception traces have no name, so add one.
             crashInstrumentation.addAttributesExtractor(
@@ -113,6 +135,7 @@ class Honeycomb {
                 .addInstrumentation(crashInstrumentation)
                 .addInstrumentation(lifecycleInstrumentation)
                 .addInstrumentation(slowRenderingInstrumentation)
+                .addInstrumentation(windowInstrumentation)
                 .build()
         }
 

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -1,25 +1,6 @@
 package io.honeycomb.opentelemetry.android
 
-import android.app.Activity
 import android.app.Application
-import android.graphics.Rect
-import android.os.Build
-import android.os.Bundle
-import android.view.ActionMode
-import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
-import android.view.KeyEvent
-import android.view.Menu
-import android.view.MenuItem
-import android.view.MotionEvent
-import android.view.SearchEvent
-import android.view.View
-import android.view.ViewGroup
-import android.view.Window
-import android.view.WindowManager
-import android.view.accessibility.AccessibilityEvent
-import android.widget.TextView
-import androidx.core.view.children
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
@@ -47,8 +28,6 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
-import kotlin.math.floor
-import kotlin.math.roundToInt
 import kotlin.time.toJavaDuration
 
 /** Creates an Attributes object from a String->String Map. */

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -145,8 +145,10 @@ private class InteractionWindowCallback(
         if (event != null) {
             val type =
                 when (event.action) {
-                    MotionEvent.ACTION_UP -> TouchEventType.TOUCH_BEGAN
-                    MotionEvent.ACTION_DOWN -> TouchEventType.TOUCH_ENDED
+                    MotionEvent.ACTION_DOWN -> TouchEventType.TOUCH_BEGAN
+                    MotionEvent.ACTION_UP -> TouchEventType.TOUCH_ENDED
+                    MotionEvent.ACTION_POINTER_DOWN -> TouchEventType.TOUCH_BEGAN
+                    MotionEvent.ACTION_POINTER_UP -> TouchEventType.TOUCH_ENDED
                     else -> null
                 }
             if (type != null) {

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -101,8 +101,19 @@ private fun findTextViewAtPosition(
         }
     }
     if (content is TextView) {
-        val rect = Rect()
-        content.getHitRect(rect)
+        val hitRect = Rect()
+        content.getHitRect(hitRect)
+
+        val location = IntArray(2)
+        content.getLocationInWindow(location)
+
+        val left = location[0]
+        val top = location[1]
+        val right = left + hitRect.width()
+        val bottom = top + hitRect.height()
+
+        val rect = Rect(left, top, right, bottom)
+
         if (rect.contains(x, y)) {
             return content
         }
@@ -115,13 +126,9 @@ private class InteractionGestureListener(
     val activity: Activity,
 ) : SimpleOnGestureListener() {
     override fun onSingleTapUp(event: MotionEvent): Boolean {
-        val contentView = activity.findViewById<View>(android.R.id.content)
-        val textView = findTextViewAtPosition(contentView, event.x.roundToInt(), event.y.roundToInt())
-        if (textView != null) {
-            val x = event.x.roundToInt()
-            val y = event.y.roundToInt()
-            recordTouchEvent(otelRum, TouchEventType.CLICK, activity, x, y)
-        }
+        val x = event.x.roundToInt()
+        val y = event.y.roundToInt()
+        recordTouchEvent(otelRum, TouchEventType.CLICK, activity, x, y)
         return super.onSingleTapUp(event)
     }
 }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -1,0 +1,271 @@
+package io.honeycomb.opentelemetry.android
+
+import android.app.Activity
+import android.app.Application
+import android.graphics.Rect
+import android.os.Build
+import android.os.Bundle
+import android.view.ActionMode
+import android.view.GestureDetector
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.SearchEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.view.accessibility.AccessibilityEvent
+import android.widget.TextView
+import androidx.core.view.children
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.api.trace.Span
+import kotlin.math.roundToInt
+
+private const val INSTRUMENTATION_NAME = "@honeycombio/instrumentation-uikit"
+
+enum class TouchEventType(val spanName: String) {
+    TOUCH_BEGAN("Touch Began"),
+    TOUCH_ENDED("Touch Ended"),
+    CLICK("click"),
+}
+
+private class ViewAttributes(activity: Activity, view: View) {
+    val className: String? = view.javaClass.canonicalName
+
+    val text: String? = if (view is TextView) view.text.toString() else null
+
+    val accessibilityClassName: String? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        view.accessibilityClassName.toString()
+    } else {
+        null
+    }
+
+    val id: Int? = if (view.id != View.NO_ID) view.id else null
+
+    val idPackage: String? = id?.let { activity.resources.getResourcePackageName(it) }
+    val idEntry: String? = id?.let { activity.resources.getResourceEntryName(it) }
+
+    val name: String? get() = idEntry ?: text
+
+    fun setAttributes(span: Span) {
+        className?.let { span.setAttribute("view.className", it) }
+        text?.let { span.setAttribute("view.text", it) }
+        accessibilityClassName?.let { span.setAttribute("view.accessibilityClassName", it) }
+        id?.let { span.setAttribute("view.id", it.toLong()) }
+        idPackage?.let { span.setAttribute("view.id.package", it) }
+        idEntry?.let { span.setAttribute("view.id.entry", it) }
+        name?.let { span.setAttribute("view.name", it) }
+    }
+}
+
+private fun recordTouchEvent(
+    otelRum: OpenTelemetryRum,
+    type: TouchEventType,
+    activity: Activity,
+    x: Int,
+    y: Int,
+) {
+    val contentView = activity.findViewById<View>(android.R.id.content)
+    val textView = findTextViewAtPosition(contentView, x, y)
+    if (textView != null) {
+        val otel = otelRum.openTelemetry
+        val tracer = otel.getTracer(INSTRUMENTATION_NAME)
+        val span = tracer.spanBuilder(type.spanName).startSpan()
+        ViewAttributes(activity, textView).setAttributes(span)
+        span.end()
+    }
+}
+
+private fun findTextViewAtPosition(content: View, x: Int, y: Int): TextView? {
+    if (content is ViewGroup) {
+        if (content.isShown) {
+            // Assuming that the developer hasn't used setZ, the controls are ordered back to front.
+            for (child in content.children.toList().reversed()) {
+                if (child.isShown) {
+                    val view = findTextViewAtPosition(child, x, y)
+                    if (view != null) {
+                        return view
+                    }
+                }
+            }
+        }
+    }
+    if (content is TextView) {
+        val rect = Rect()
+        content.getHitRect(rect)
+        if (rect.contains(x, y)) {
+            return content
+        }
+    }
+    return null
+}
+
+private class InteractionGestureListener(
+    val otelRum: OpenTelemetryRum,
+    val activity: Activity
+): SimpleOnGestureListener() {
+    override fun onSingleTapUp(event: MotionEvent): Boolean {
+        val contentView = activity.findViewById<View>(android.R.id.content)
+        val textView = findTextViewAtPosition(contentView, event.x.roundToInt(), event.y.roundToInt())
+        if (textView != null) {
+            val x = event.x.roundToInt()
+            val y = event.y.roundToInt()
+            recordTouchEvent(otelRum, TouchEventType.CLICK, activity, x, y)
+        }
+        return super.onSingleTapUp(event)
+    }
+}
+
+private class InteractionWindowCallback(
+    val otelRum: OpenTelemetryRum,
+    val activity: Activity,
+    val wrapped: Window.Callback
+) : Window.Callback {
+    val gestureDetector = GestureDetector(activity, InteractionGestureListener(otelRum, activity))
+
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        return wrapped.dispatchKeyEvent(event)
+    }
+
+    override fun dispatchKeyShortcutEvent(event: KeyEvent?): Boolean {
+        return wrapped.dispatchKeyShortcutEvent(event)
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        if (event != null) {
+            val type = when(event.action) {
+                MotionEvent.ACTION_UP -> TouchEventType.TOUCH_BEGAN
+                MotionEvent.ACTION_DOWN -> TouchEventType.TOUCH_ENDED
+                else -> null
+            }
+            if (type != null) {
+                val x = event.x.roundToInt()
+                val y = event.y.roundToInt()
+                recordTouchEvent(otelRum, type, activity, x, y)
+            }
+            gestureDetector.onTouchEvent(event)
+        }
+        return wrapped.dispatchTouchEvent(event)
+    }
+
+    override fun dispatchTrackballEvent(event: MotionEvent?): Boolean {
+        return wrapped.dispatchTrackballEvent(event)
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent?): Boolean {
+        return wrapped.dispatchGenericMotionEvent(event)
+    }
+
+    override fun dispatchPopulateAccessibilityEvent(event: AccessibilityEvent?): Boolean {
+        return wrapped.dispatchPopulateAccessibilityEvent(event)
+    }
+
+    override fun onCreatePanelView(featureId: Int): View? {
+        return wrapped.onCreatePanelView(featureId)
+    }
+
+    override fun onCreatePanelMenu(featureId: Int, menu: Menu): Boolean {
+        return wrapped.onCreatePanelMenu(featureId, menu)
+    }
+
+    override fun onPreparePanel(featureId: Int, view: View?, menu: Menu): Boolean {
+        return wrapped.onPreparePanel(featureId, view, menu)
+    }
+
+    override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
+        return wrapped.onMenuOpened(featureId, menu)
+    }
+
+    override fun onMenuItemSelected(featureId: Int, item: MenuItem): Boolean {
+        return wrapped.onMenuItemSelected(featureId, item)
+    }
+
+    override fun onWindowAttributesChanged(params: WindowManager.LayoutParams?) {
+        return wrapped.onWindowAttributesChanged(params)
+    }
+
+    override fun onContentChanged() {
+        return wrapped.onContentChanged()
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        return wrapped.onWindowFocusChanged(hasFocus)
+    }
+
+    override fun onAttachedToWindow() {
+        return wrapped.onAttachedToWindow()
+    }
+
+    override fun onDetachedFromWindow() {
+        return wrapped.onDetachedFromWindow()
+    }
+
+    override fun onPanelClosed(featureId: Int, menu: Menu) {
+        return wrapped.onPanelClosed(featureId, menu)
+    }
+
+    override fun onSearchRequested(): Boolean {
+        return wrapped.onSearchRequested()
+    }
+
+    override fun onSearchRequested(event: SearchEvent?): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            wrapped.onSearchRequested(event)
+        } else {
+            // Do nothing
+            false
+        }
+    }
+
+    override fun onWindowStartingActionMode(callback: ActionMode.Callback?): ActionMode? {
+        return wrapped.onWindowStartingActionMode(callback)
+    }
+
+    override fun onWindowStartingActionMode(callback: ActionMode.Callback?, type: Int): ActionMode? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            wrapped.onWindowStartingActionMode(callback, type)
+        } else {
+            null
+        }
+    }
+
+    override fun onActionModeStarted(mode: ActionMode?) {
+        return wrapped.onActionModeStarted(mode)
+    }
+
+    override fun onActionModeFinished(mode: ActionMode?) {
+        return wrapped.onActionModeFinished(mode)
+    }
+}
+
+private class InteractionLifecycleCallbacks(
+    val otelRum: OpenTelemetryRum
+) : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+        activity.window.callback = InteractionWindowCallback(otelRum, activity, activity.window.callback)
+    }
+
+    override fun onActivityStarted(p0: Activity) {}
+
+    override fun onActivityResumed(p0: Activity) {}
+
+    override fun onActivityPaused(p0: Activity) {}
+
+    override fun onActivityStopped(p0: Activity) {}
+
+    override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) {}
+
+    override fun onActivityDestroyed(p0: Activity) {}
+}
+
+@AutoService(AndroidInstrumentation::class)
+class WindowInstrumentation : AndroidInstrumentation {
+    override fun install(application: Application, openTelemetryRum: OpenTelemetryRum) {
+        application.registerActivityLifecycleCallbacks(InteractionLifecycleCallbacks(openTelemetryRum))
+    }
+}

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -39,11 +39,12 @@ private class ViewAttributes(activity: Activity, view: View) {
 
     val text: String? = if (view is TextView) view.text.toString() else null
 
-    val accessibilityClassName: String? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        view.accessibilityClassName.toString()
-    } else {
-        null
-    }
+    val accessibilityClassName: String? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            view.accessibilityClassName.toString()
+        } else {
+            null
+        }
 
     val id: Int? = if (view.id != View.NO_ID) view.id else null
 
@@ -81,7 +82,11 @@ private fun recordTouchEvent(
     }
 }
 
-private fun findTextViewAtPosition(content: View, x: Int, y: Int): TextView? {
+private fun findTextViewAtPosition(
+    content: View,
+    x: Int,
+    y: Int,
+): TextView? {
     if (content is ViewGroup) {
         if (content.isShown) {
             // Assuming that the developer hasn't used setZ, the controls are ordered back to front.
@@ -107,8 +112,8 @@ private fun findTextViewAtPosition(content: View, x: Int, y: Int): TextView? {
 
 private class InteractionGestureListener(
     val otelRum: OpenTelemetryRum,
-    val activity: Activity
-): SimpleOnGestureListener() {
+    val activity: Activity,
+) : SimpleOnGestureListener() {
     override fun onSingleTapUp(event: MotionEvent): Boolean {
         val contentView = activity.findViewById<View>(android.R.id.content)
         val textView = findTextViewAtPosition(contentView, event.x.roundToInt(), event.y.roundToInt())
@@ -124,7 +129,7 @@ private class InteractionGestureListener(
 private class InteractionWindowCallback(
     val otelRum: OpenTelemetryRum,
     val activity: Activity,
-    val wrapped: Window.Callback
+    val wrapped: Window.Callback,
 ) : Window.Callback {
     val gestureDetector = GestureDetector(activity, InteractionGestureListener(otelRum, activity))
 
@@ -138,11 +143,12 @@ private class InteractionWindowCallback(
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
         if (event != null) {
-            val type = when(event.action) {
-                MotionEvent.ACTION_UP -> TouchEventType.TOUCH_BEGAN
-                MotionEvent.ACTION_DOWN -> TouchEventType.TOUCH_ENDED
-                else -> null
-            }
+            val type =
+                when (event.action) {
+                    MotionEvent.ACTION_UP -> TouchEventType.TOUCH_BEGAN
+                    MotionEvent.ACTION_DOWN -> TouchEventType.TOUCH_ENDED
+                    else -> null
+                }
             if (type != null) {
                 val x = event.x.roundToInt()
                 val y = event.y.roundToInt()
@@ -169,19 +175,32 @@ private class InteractionWindowCallback(
         return wrapped.onCreatePanelView(featureId)
     }
 
-    override fun onCreatePanelMenu(featureId: Int, menu: Menu): Boolean {
+    override fun onCreatePanelMenu(
+        featureId: Int,
+        menu: Menu,
+    ): Boolean {
         return wrapped.onCreatePanelMenu(featureId, menu)
     }
 
-    override fun onPreparePanel(featureId: Int, view: View?, menu: Menu): Boolean {
+    override fun onPreparePanel(
+        featureId: Int,
+        view: View?,
+        menu: Menu,
+    ): Boolean {
         return wrapped.onPreparePanel(featureId, view, menu)
     }
 
-    override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
+    override fun onMenuOpened(
+        featureId: Int,
+        menu: Menu,
+    ): Boolean {
         return wrapped.onMenuOpened(featureId, menu)
     }
 
-    override fun onMenuItemSelected(featureId: Int, item: MenuItem): Boolean {
+    override fun onMenuItemSelected(
+        featureId: Int,
+        item: MenuItem,
+    ): Boolean {
         return wrapped.onMenuItemSelected(featureId, item)
     }
 
@@ -205,7 +224,10 @@ private class InteractionWindowCallback(
         return wrapped.onDetachedFromWindow()
     }
 
-    override fun onPanelClosed(featureId: Int, menu: Menu) {
+    override fun onPanelClosed(
+        featureId: Int,
+        menu: Menu,
+    ) {
         return wrapped.onPanelClosed(featureId, menu)
     }
 
@@ -226,7 +248,10 @@ private class InteractionWindowCallback(
         return wrapped.onWindowStartingActionMode(callback)
     }
 
-    override fun onWindowStartingActionMode(callback: ActionMode.Callback?, type: Int): ActionMode? {
+    override fun onWindowStartingActionMode(
+        callback: ActionMode.Callback?,
+        type: Int,
+    ): ActionMode? {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             wrapped.onWindowStartingActionMode(callback, type)
         } else {
@@ -244,9 +269,12 @@ private class InteractionWindowCallback(
 }
 
 private class InteractionLifecycleCallbacks(
-    val otelRum: OpenTelemetryRum
+    val otelRum: OpenTelemetryRum,
 ) : Application.ActivityLifecycleCallbacks {
-    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+    override fun onActivityCreated(
+        activity: Activity,
+        bundle: Bundle?,
+    ) {
         activity.window.callback = InteractionWindowCallback(otelRum, activity, activity.window.callback)
     }
 
@@ -258,14 +286,20 @@ private class InteractionLifecycleCallbacks(
 
     override fun onActivityStopped(p0: Activity) {}
 
-    override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) {}
+    override fun onActivitySaveInstanceState(
+        p0: Activity,
+        p1: Bundle,
+    ) {}
 
     override fun onActivityDestroyed(p0: Activity) {}
 }
 
 @AutoService(AndroidInstrumentation::class)
 class WindowInstrumentation : AndroidInstrumentation {
-    override fun install(application: Application, openTelemetryRum: OpenTelemetryRum) {
+    override fun install(
+        application: Application,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
         application.registerActivityLifecycleCallbacks(InteractionLifecycleCallbacks(openTelemetryRum))
     }
 }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -89,7 +89,8 @@ private fun findTextViewAtPosition(
 ): TextView? {
     if (content is ViewGroup) {
         if (content.isShown) {
-            // Assuming that the developer hasn't used setZ, the controls are ordered back to front.
+            // Empirically, this seems to be the order that Android uses to find the touch target,
+            // even if the developer has used setZ to override the render order.
             for (child in content.children.toList().reversed()) {
                 if (child.isShown) {
                     val view = findTextViewAtPosition(child, x, y)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/WindowInstrumentation.kt
@@ -26,7 +26,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.trace.Span
 import kotlin.math.roundToInt
 
-private const val INSTRUMENTATION_NAME = "@honeycombio/instrumentation-uikit"
+private const val INSTRUMENTATION_NAME = "@honeycombio/instrumentation-ui"
 
 enum class TouchEventType(val spanName: String) {
     TOUCH_BEGAN("Touch Began"),
@@ -54,7 +54,7 @@ private class ViewAttributes(activity: Activity, view: View) {
     val name: String? get() = idEntry ?: text
 
     fun setAttributes(span: Span) {
-        className?.let { span.setAttribute("view.className", it) }
+        className?.let { span.setAttribute("view.class", it) }
         text?.let { span.setAttribute("view.text", it) }
         accessibilityClassName?.let { span.setAttribute("view.accessibilityClassName", it) }
         id?.let { span.setAttribute("view.id", it.toLong()) }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -88,10 +88,11 @@ dependencies {
 
     testImplementation(libs.junit)
 
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.androidx.uiautomator)
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -16,7 +16,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
 /**
  * Instrumented test, which will execute on an Android device.
  *

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -4,9 +4,12 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
@@ -83,23 +86,22 @@ class HoneycombSmokeTest {
         rule.onNodeWithText("Normal").performClick()
     }
 
+    private fun buttonSelector(text: String): BySelector {
+        return By.text(text.toUpperCase(Locale.current)).clazz("android.widget.Button")
+    }
+
     @Test
     fun touchInstrumentation_works() {
         rule.onNodeWithText("UI").performClick()
         rule.onNodeWithText("Start XML UI").performClick()
 
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.wait(Until.hasObject(buttonSelector("Example Button")), 1000)
 
-        val exampleButton: UiObject2? =
-            device.findObject(
-                By.text("EXAMPLE BUTTON").clazz("android.widget.Button"),
-            )
+        val exampleButton: UiObject2? = device.findObject(buttonSelector("Example Button"))
         exampleButton!!.click()
 
-        val backButton: UiObject2? =
-            device.findObject(
-                By.text("BACK").clazz("android.widget.Button"),
-            )
-        backButton!!.clickAndWait(Until.newWindow(), 5000)
+        val backButton: UiObject2? = device.findObject(buttonSelector("Back"))
+        backButton!!.clickAndWait(Until.newWindow(), 1000)
     }
 }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -9,11 +9,13 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -99,6 +101,6 @@ class HoneycombSmokeTest {
             device.findObject(
                 By.text("BACK").clazz("android.widget.Button"),
             )
-        backButton!!.click()
+        backButton!!.clickAndWait(Until.newWindow(), 5000)
     }
 }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -6,6 +6,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -77,5 +81,23 @@ class HoneycombSmokeTest {
         rule.onNodeWithText("Frozen").performClick()
         Thread.sleep(1000)
         rule.onNodeWithText("Normal").performClick()
+    }
+
+    @Test
+    fun touchInstrumentation_works() {
+        rule.onNodeWithText("UI").performClick()
+        rule.onNodeWithText("Start XML UI").performClick()
+
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        val exampleButton: UiObject2? = device.findObject(
+            By.text("EXAMPLE BUTTON").clazz("android.widget.Button")
+        )
+        exampleButton!!.click()
+
+        val backButton: UiObject2? = device.findObject(
+            By.text("BACK").clazz("android.widget.Button")
+        )
+        backButton!!.click()
     }
 }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -6,10 +6,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
-import androidx.test.uiautomator.Until
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -90,14 +89,16 @@ class HoneycombSmokeTest {
 
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        val exampleButton: UiObject2? = device.findObject(
-            By.text("EXAMPLE BUTTON").clazz("android.widget.Button")
-        )
+        val exampleButton: UiObject2? =
+            device.findObject(
+                By.text("EXAMPLE BUTTON").clazz("android.widget.Button"),
+            )
         exampleButton!!.click()
 
-        val backButton: UiObject2? = device.findObject(
-            By.text("BACK").clazz("android.widget.Button")
-        )
+        val backButton: UiObject2? =
+            device.findObject(
+                By.text("BACK").clazz("android.widget.Button"),
+            )
         backButton!!.click()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,12 @@
 [versions]
+activity = "1.9.3"
 activityCompose = "1.9.0"
 agp = "8.5.0"
+appcompat = "1.7.0"
+autoService = "1.1.1"
 bytebuddy = "1.15.5"
 composeBom = "2024.04.01"
+constraintlayout = "2.1.4"
 coreKtx = "1.13.1"
 desugarLibs = "2.0.4"
 espressoCore = "3.6.1"
@@ -10,18 +14,15 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "1.9.0"
 lifecycleRuntimeKtx = "2.8.3"
+material = "1.12.0"
 mockitoCore = "4.11.0"
 mockitoKotlin = "4.1.0"
+okhttp = "4.12.0"
 opentelemetry = "1.38.0"
 opentelemetryAndroid = "0.7.0-alpha"
 opentelemetryInstrumentation = "2.7.0"
 publish = "1.3.0"
-okhttp = "4.12.0"
 spotless = "6.25.0"
-appcompat = "1.7.0"
-material = "1.12.0"
-activity = "1.9.3"
-constraintlayout = "2.1.4"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -38,6 +39,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarLibs" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,12 +23,17 @@ opentelemetryAndroid = "0.7.0-alpha"
 opentelemetryInstrumentation = "2.7.0"
 publish = "1.3.0"
 spotless = "6.25.0"
+uiautomator = "2.4.0-alpha01"
 
 [libraries]
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
@@ -50,6 +55,7 @@ instrumentation-activity = { module = "io.opentelemetry.android:instrumentation-
 instrumentation-anr = { module = "io.opentelemetry.android:instrumentation-anr", version.ref = "opentelemetryAndroid"  }
 instrumentation-crash = { module = "io.opentelemetry.android:instrumentation-crash", version.ref = "opentelemetryAndroid"  }
 instrumentation-slowrendering = { module = "io.opentelemetry.android:instrumentation-slowrendering", version.ref = "opentelemetryAndroid"  }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-agent = { module = "io.opentelemetry.android:okhttp-3.0-agent", version.ref = "opentelemetryAndroid" }
 okhttp-library = { module = "io.opentelemetry.android:okhttp-3.0-library", version.ref = "opentelemetryAndroid" }
@@ -58,10 +64,6 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref
 opentelemetry-exporter-logging-otlp = { module = "io.opentelemetry:opentelemetry-exporter-logging-otlp", version.ref = "opentelemetry" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry"  }
 opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api", version.ref = "opentelemetryInstrumentation"  }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -38,3 +38,34 @@ teardown_file() {
   assert_equal "$result" '"GET"'
 }
 
+@test "UI touch events are captured" {
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "Touch Began" "example_button")
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "Touch Ended" "example_button")
+}
+
+@test "UI click events are captured" {
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "click" "example_button")
+}
+
+@test "UI touch events have all attributes" {
+    span=$(spans_on_view_named "@honeycombio/instrumentation-ui" "click" "example_button")
+
+    name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
+    assert_equal "$name" '"example_button"'
+
+    class=$(echo "$span" | jq '.attributes[] | select(.key == "view.class").value.stringValue')
+    assert_equal "$class" '"android.widget.Button"'
+
+    class=$(echo "$span" | jq '.attributes[] | select(.key == "view.accessibilityClassName").value.stringValue')
+    assert_equal "$class" '"android.widget.Button"'
+
+    text=$(echo "$span" | jq '.attributes[] | select(.key == "view.text").value.stringValue')
+    assert_equal "$text" '"Example Button"'
+
+    package=$(echo "$span" | jq '.attributes[] | select(.key == "view.id.package").value.stringValue')
+    assert_equal "$package" '"io.honeycomb.opentelemetry.android.example"'
+
+    entry=$(echo "$span" | jq '.attributes[] | select(.key == "view.id.entry").value.stringValue')
+    assert_equal "$entry" '"example_button"'
+}
+

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -1,5 +1,19 @@
 # UTILITY FUNCS
 
+# Spans on a particular view.
+# Arguments:
+#   $1 - scope
+#   $2 - span name
+#   $3 - view.name
+spans_on_view_named() {
+    spans_received | jq ".scopeSpans[] \
+        | select(.scope.name == \"$1\").spans[] \
+        | select (.name == \"$2\") as \$span \
+        | .attributes?[]? \
+        | select (.key? == \"view.name\" and .value.stringValue == \"$3\") \
+        | \$span"
+}
+
 # Span names for a given scope
 # Arguments: $1 - scope name
 span_names_for() {
@@ -77,9 +91,24 @@ assert_equal() {
 
 # Fail and display details if the actual value is empty.
 # Arguments: $1 - actual result
-assert_not_empty() {
+assert_not_empty_string() {
 	EMPTY=(\"\")
 	if [[ "$1" == "${EMPTY}" ]]; then
+		{
+			echo
+			echo "-- 💥 value is empty 💥 --"
+			echo "value : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}
+
+# Fail and display details if the actual value is empty.
+# Arguments: $1 - actual result
+assert_not_empty() {
+	if [[ "$1" == "" ]]; then
 		{
 			echo
 			echo "-- 💥 value is empty 💥 --"


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds auto-instrumentation for capturing touch events on XML-based Activities.

## Short description of the changes

The events and attributes are intended to be as close as possible to the Swift versions, changing attributes only as needed to make sense.

One caveat is that these "clicks" are actually "taps" and don't necessarily match up to what is a "click" according to a `Button` or other control itself. This is the best we can do in a reasonable amount of time, and developers can always use manual instrumentation to capture the official clicks. We _may_ want to change the behavior in Swift later to match this more closely, and we _may_ want to rename "click" to "tap". But those decisions don't need to block this PR.

## How to verify that this has the expected result

`make smoke`