### PR TITLE
fix: make XML UI smoke tests more robust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
           system-image: system-images;android-30;google_apis;x86
           test-command: ./gradlew :example:connectedDebugAndroidTest
           max-tries: 1
+      - store_artifacts:
+          path: example/build/outputs/connected_android_test_additional_output
       - run:
           name: "Run Smoke Tests"
           command: make smoke-bats

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -21,6 +21,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+val UI_WAIT_TIMEOUT = 10.seconds
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -63,7 +67,7 @@ class HoneycombSmokeTest {
         rule.onNodeWithText("Network").performClick()
         rule.onNodeWithText("Make a Network Request").performClick()
 
-        rule.waitUntil(5000) {
+        rule.waitUntil(UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS)) {
             rule.onNodeWithText("Network Request Succeeded", true).isDisplayed()
         }
     }
@@ -77,7 +81,8 @@ class HoneycombSmokeTest {
     fun slowRendersDetection_works() {
         rule.onNodeWithText("UI").performClick()
         rule.onNodeWithText("Slow").performClick()
-        Thread.sleep(1000)
+        // Let it do slow renders for two seconds to capture some traces.
+        Thread.sleep(2000)
         rule.onNodeWithText("Normal").performClick()
     }
 
@@ -85,7 +90,8 @@ class HoneycombSmokeTest {
     fun frozenRendersDetection_works() {
         rule.onNodeWithText("UI").performClick()
         rule.onNodeWithText("Frozen").performClick()
-        Thread.sleep(1000)
+        // Let it do frozen renders for two seconds to capture some traces.
+        Thread.sleep(2000)
         rule.onNodeWithText("Normal").performClick()
     }
 
@@ -99,13 +105,23 @@ class HoneycombSmokeTest {
         rule.onNodeWithText("Start XML UI").performClick()
 
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.wait(Until.hasObject(buttonSelector("Example Button")), 1000)
 
-        val exampleButton: UiObject2? = device.findObject(buttonSelector("Example Button"))
+        val exampleButton: UiObject2? =
+            device.wait(
+                Until.findObject(buttonSelector("Example Button")),
+                UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
+            )
         exampleButton!!.click()
 
-        val backButton: UiObject2? = device.findObject(buttonSelector("Back"))
-        backButton!!.clickAndWait(Until.newWindow(), 1000)
+        val backButton: UiObject2? =
+            device.wait(
+                Until.findObject(buttonSelector("Back")),
+                UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
+            )
+        backButton!!.clickAndWait(
+            Until.newWindow(),
+            UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
+        )
     }
 
     @Test
@@ -113,9 +129,8 @@ class HoneycombSmokeTest {
         rule.onNodeWithText("Render").performClick()
         rule.onNodeWithTag("slow_render_switch").performClick()
 
-        rule.waitUntil(5000) {
+        rule.waitUntil(UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS)) {
             rule.onAllNodesWithText("slow text", true).assertCountEquals(5)
-
             true
         }
 

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -135,7 +135,7 @@ class HoneycombSmokeTest {
         // If it _is_ an ANR dialog, then attempt to close it.
         val waitButton: UiObject2? =
             device.wait(
-                Until.findObject(buttonSelector("Wait")),
+                Until.findObject(By.text("Wait")),
                 UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
             )
         waitButton?.click()

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -25,7 +25,11 @@ import java.io.File
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
+// How long to wait for the UI to update between interactions.
 val UI_WAIT_TIMEOUT = 5.seconds
+
+// This is a special directory that will be saved to the build directory after the test finishes.
+const val ADDITIONAL_TEST_OUTPUT_DIRECTORY = "/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output"
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -121,8 +125,7 @@ class HoneycombSmokeTest {
 
         if (retries <= 0) {
             // We failed, so attempt to take a screenshot and throw an exception.
-            // This is a special directory that will be saved to the build directory after the test finishes.
-            val screenshotPath = File("/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output/failure.png")
+            val screenshotPath = File(ADDITIONAL_TEST_OUTPUT_DIRECTORY, "getButton_failure.png")
             if (device.takeScreenshot(screenshotPath)) {
                 throw RuntimeException("Example Button missing. See screenshot at $screenshotPath")
             } else {

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -100,18 +100,17 @@ class HoneycombSmokeTest {
         return By.text(text.toUpperCase(Locale.current)).clazz("android.widget.Button")
     }
 
+    @Test
     fun touchInstrumentation_works() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
         rule.onNodeWithText("UI").performClick()
         rule.onNodeWithText("Start XML UI").performClick()
 
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val exampleButton: UiObject2? =
             device.wait(
                 Until.findObject(buttonSelector("Example Button")),
                 UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
             )
-
         if (exampleButton == null) {
             // This is a special directory that will be saved to the build directory after the test finishes.
             val screenshotPath = File("/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output/failure.png")

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
@@ -99,19 +100,28 @@ class HoneycombSmokeTest {
         return By.text(text.toUpperCase(Locale.current)).clazz("android.widget.Button")
     }
 
-    @Test
     fun touchInstrumentation_works() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
         rule.onNodeWithText("UI").performClick()
         rule.onNodeWithText("Start XML UI").performClick()
-
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         val exampleButton: UiObject2? =
             device.wait(
                 Until.findObject(buttonSelector("Example Button")),
                 UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
             )
-        exampleButton!!.click()
+
+        if (exampleButton == null) {
+            // This is a special directory that will be saved to the build directory after the test finishes.
+            val screenshotPath = File("/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output/failure.png")
+            if (device.takeScreenshot(screenshotPath)) {
+                throw RuntimeException("Example Button missing. See screenshot at $screenshotPath")
+            } else {
+                throw RuntimeException("Example Button missing. Unable to take screenshot.")
+            }
+        }
+        exampleButton.click()
 
         val backButton: UiObject2? =
             device.wait(

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -107,7 +107,7 @@ class HoneycombSmokeTest {
     private fun getButton(
         device: UiDevice,
         text: String,
-        retries: Int = 3
+        retries: Int = 3,
     ): UiObject2 {
         // Attempt to get the button.
         val button: UiObject2? =


### PR DESCRIPTION
## Which problem is this PR solving?

Smoke tests are flaky when running on circleci, but not locally. The underlying cause is a system ANR dialog popping up and blocking access to the app.

## Short description of the changes

Changed the code that gets buttons in the XML UI to:
* wait longer before giving up
* retry when the button isn't found
* dismiss any possible ANR dialog between retries
* take a screenshot if the button still isn't found after the retries
* upload the screenshot to circleci as an artifact

## How to verify that this has the expected result

The tests have been run 5 times in a row without failing.