### PR TITLE
chore: include `telemetry.sdk.language` resource attribute

### DIFF
--- a/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombOptionsInstrumentedTest.kt
+++ b/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombOptionsInstrumentedTest.kt
@@ -28,6 +28,7 @@ class HoneycombOptionsInstrumentedTest {
                 "service.name" to "unknown_service",
                 "honeycomb.distro.version" to "0.0.1-alpha",
                 "honeycomb.distro.runtime_version" to Build.VERSION.RELEASE,
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -63,7 +63,7 @@ class Honeycomb {
                 }
 
             val resource =
-                Resource.builder().putAll(createAttributes(options.resourceAttributes)).build()
+                Resource.getDefault().toBuilder().putAll(createAttributes(options.resourceAttributes)).build()
             val rumConfig = OtelRumConfig()
 
             val windowInstrumentation = WindowInstrumentation()

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -446,6 +446,12 @@ data class HoneycombOptions(
                 Build.VERSION.RELEASE ?: "unknown",
             )
 
+            // The language is technically Kotlin, but Android apps can be Java or Kotlin or both, so:
+            resourceAttributes.putIfAbsent(
+                "telemetry.sdk.language",
+                "android",
+            )
+
             val tracesApiKey = this.tracesApiKey ?: defaultApiKey()
             val metricsApiKey = this.metricsApiKey ?: defaultApiKey()
             val logsApiKey = this.logsApiKey ?: defaultApiKey()

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -60,6 +60,7 @@ class HoneycombOptionsUnitTest {
                 "service.name" to "unknown_service",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -115,6 +116,7 @@ class HoneycombOptionsUnitTest {
                 "service.name" to "unknown_service",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -169,6 +171,7 @@ class HoneycombOptionsUnitTest {
                 "resource" to "aaa",
                 "honeycomb.distro.version" to "0.0.3-alpha",
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -241,6 +244,7 @@ class HoneycombOptionsUnitTest {
                 "resource" to "aaa",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -330,6 +334,7 @@ class HoneycombOptionsUnitTest {
                 "resource" to "aaa",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -409,6 +414,7 @@ class HoneycombOptionsUnitTest {
                 "resource" to "aaa",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -619,6 +625,7 @@ class HoneycombOptionsUnitTest {
                 "service.name" to "resource_name",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -638,6 +645,7 @@ class HoneycombOptionsUnitTest {
                 "service.name" to "better",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )
@@ -653,6 +661,7 @@ class HoneycombOptionsUnitTest {
                 "service.name" to "unknown_service",
                 "honeycomb.distro.version" to BuildConfig.HONEYCOMB_DISTRO_VERSION,
                 "honeycomb.distro.runtime_version" to "unknown",
+                "telemetry.sdk.language" to "android",
             ),
             options.resourceAttributes,
         )

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -17,6 +17,19 @@ teardown_file() {
   assert_equal "$result" "1"
 }
 
+@test "SDK sends correct resource attributes" {
+  result=$(resource_attributes_received | sort | uniq)
+  assert_equal "$result" '"honeycomb.distro.runtime_version"
+"honeycomb.distro.version"
+"service.name"
+"telemetry.sdk.language"
+"telemetry.sdk.name"
+"telemetry.sdk.version"'
+
+  result=$(resource_attribute_named "telemetry.sdk.language" "string" | uniq)
+  assert_equal "$result" '"android"'
+}
+
 @test "SDK can send spans" {
   result=$(span_names_for ${SMOKE_TEST_SCOPE})
   assert_equal "$result" '"test-span"'

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -71,7 +71,11 @@ attributes_from_span_named() {
 
 # All resource attributes
 resource_attributes_received() {
-	spans_received | jq ".resource.attributes[]?"
+	spans_received | jq ".resource.attributes[]?.key"
+}
+
+resource_attribute_named() {
+    spans_received | jq ".resource.attributes[]? | select(.key == \"$1\").value.${2}Value"
 }
 
 # Spans for a given scope


### PR DESCRIPTION
## Which problem is this PR solving?
Clients of the SDK want to know where their traces are coming from.


## Short description of the changes

includes `telemetry.sdk.language` as a default resource attribute

## How to verify that this has the expected result
- [x] unit tests pass