### PR TITLE
chore: explicitly drop to jdk 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - checkout
       - android/restore-gradle-cache
+      - android/change-java-version:
+          java-version: 17
       - android/run-tests:
           test-command: ./gradlew testDebug
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ orbs:
   android: circleci/android@2.5
   bats: circleci/bats@1.0.0
 
+parameters:
+  java-version:
+    type: integer
+    default: 17
+
 jobs:
   unit_test:
     executor:
@@ -15,7 +20,7 @@ jobs:
       - checkout
       - android/restore-gradle-cache
       - android/change-java-version:
-          java-version: 17
+          java-version: << pipeline.parameters.java-version >>
       - android/run-tests:
           test-command: ./gradlew testDebug
       - android/save-gradle-cache
@@ -27,6 +32,8 @@ jobs:
     steps:
       - checkout
       - android/restore-gradle-cache
+      - android/change-java-version:
+          java-version: << pipeline.parameters.java-version >>
       - run:
           name: "Run Spotless"
           command: ./gradlew spotlessCheck
@@ -46,6 +53,8 @@ jobs:
       - run:
           name: "Start Collector & Mock Server"
           command: make smoke-docker
+      - android/change-java-version:
+          java-version: << pipeline.parameters.java-version >>
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           test-command: ./gradlew :example:connectedDebugAndroidTest
@@ -61,6 +70,8 @@ jobs:
     steps:
       - checkout
       - android/restore-gradle-cache
+      - android/change-java-version:
+          java-version: << pipeline.parameters.java-version >>
       - android/restore-build-cache
       - run:
           name: Assemble release build
@@ -74,6 +85,8 @@ jobs:
       tag: default
     steps:
       - checkout
+      - android/change-java-version:
+          java-version: << pipeline.parameters.java-version >>
       - run:
           name: "Publish Artifacts to Maven"
           command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">


### PR DESCRIPTION
## Which problem is this PR solving?
While working on #24, I noticed Android Studio had updated the compiler config in the `.idea` directory to drop down to java compiler 17 (instead of 21). 

Similarly, I started seeing warnings like

```
> Task :core:compileDebugJavaWithJavac
Java compiler version 21 has deprecated support for compiling with source/target version 8.
Try one of the following options:
    1. [Recommended] Use Java toolchain with a lower language version
    2. Set a higher source/target version
    3. Use a lower version of the JDK running the build (if you're not using Java toolchain)
For more details on how to configure these settings, see https://developer.android.com/build/jdks.
To suppress this warning, set android.javaCompile.suppressSourceTargetDeprecationWarning=true in gradle.properties.
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings
```
([job link](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-android/314/workflows/4554f6fc-9054-484f-b9be-9b4d550befdf/jobs/887))

The documentation for the CircleCI Android orb implies that Java 17 is the default but clearly it's actually using Java 21. 

## Short description of the changes
This PR updates our CircleCI config to explicitly use 17, and commits the updated Android Studio config to keep local dev environments in line. 

## How to verify that this has the expected result
[The same job](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-android/320/workflows/5a1065e9-47d1-4e2f-941e-ac546bec7238/jobs/901) no longer spits out the `Java compiler version 21` warning