### PR TITLE
feat(samplers): add deterministic sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+* feat: Add deterministic sampler
 * refactor: Move touch auto-instrumentation to separate package
-* feat: Add instrumentation package for Android Compose
+* feat: Add instrumentation helpers for Android Compose
 
 ## v0.0.3-alpha
 

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
@@ -1,0 +1,44 @@
+package io.honeycomb.opentelemetry.android
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.data.LinkData
+import io.opentelemetry.sdk.trace.samplers.Sampler
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision
+import io.opentelemetry.sdk.trace.samplers.SamplingResult
+
+class HoneycombDeterministicSampler(private val sampleRate: Int) : Sampler {
+    private val inner: Sampler = if (sampleRate < 1) {
+        Sampler.alwaysOff()
+    } else if (sampleRate == 1) {
+        Sampler.alwaysOn()
+    } else {
+        Sampler.traceIdRatioBased(1.0 / sampleRate)
+    }
+
+    override fun shouldSample(context: Context, traceId: String, name: String, spanKind: SpanKind, attributes: Attributes, parentLinks: MutableList<LinkData>): SamplingResult {
+        var result = this.inner.shouldSample(context, traceId, name, spanKind, attributes, parentLinks)
+
+        if (result.decision != SamplingDecision.DROP) {
+            val attrs = result.attributes.toBuilder().put("SampleRate", sampleRate.toDouble()).build()
+            result = SamplingResult.create(result.decision, attrs)
+        }
+
+        return result
+    }
+
+    override fun getDescription(): String {
+        return "DeterministicSampler"
+    }
+}
+
+//private class HoneycombDecision(val decision: SamplingDecision, val attributes: Attributes) : SamplingResult {
+//    override fun getDecision(): SamplingDecision {
+//        return decision
+//    }
+//
+//    override fun getAttributes(): Attributes {
+//        return attributes
+//    }
+//}

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
@@ -40,13 +40,3 @@ class HoneycombDeterministicSampler(private val sampleRate: Int) : Sampler {
         return "DeterministicSampler"
     }
 }
-
-// private class HoneycombDecision(val decision: SamplingDecision, val attributes: Attributes) : SamplingResult {
-//    override fun getDecision(): SamplingDecision {
-//        return decision
-//    }
-//
-//    override fun getAttributes(): Attributes {
-//        return attributes
-//    }
-// }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSampler.kt
@@ -9,15 +9,23 @@ import io.opentelemetry.sdk.trace.samplers.SamplingDecision
 import io.opentelemetry.sdk.trace.samplers.SamplingResult
 
 class HoneycombDeterministicSampler(private val sampleRate: Int) : Sampler {
-    private val inner: Sampler = if (sampleRate < 1) {
-        Sampler.alwaysOff()
-    } else if (sampleRate == 1) {
-        Sampler.alwaysOn()
-    } else {
-        Sampler.traceIdRatioBased(1.0 / sampleRate)
-    }
+    private val inner: Sampler =
+        if (sampleRate < 1) {
+            Sampler.alwaysOff()
+        } else if (sampleRate == 1) {
+            Sampler.alwaysOn()
+        } else {
+            Sampler.traceIdRatioBased(1.0 / sampleRate)
+        }
 
-    override fun shouldSample(context: Context, traceId: String, name: String, spanKind: SpanKind, attributes: Attributes, parentLinks: MutableList<LinkData>): SamplingResult {
+    override fun shouldSample(
+        context: Context,
+        traceId: String,
+        name: String,
+        spanKind: SpanKind,
+        attributes: Attributes,
+        parentLinks: MutableList<LinkData>,
+    ): SamplingResult {
         var result = this.inner.shouldSample(context, traceId, name, spanKind, attributes, parentLinks)
 
         if (result.decision != SamplingDecision.DROP) {
@@ -33,7 +41,7 @@ class HoneycombDeterministicSampler(private val sampleRate: Int) : Sampler {
     }
 }
 
-//private class HoneycombDecision(val decision: SamplingDecision, val attributes: Attributes) : SamplingResult {
+// private class HoneycombDecision(val decision: SamplingDecision, val attributes: Attributes) : SamplingResult {
 //    override fun getDecision(): SamplingDecision {
 //        return decision
 //    }
@@ -41,4 +49,4 @@ class HoneycombDeterministicSampler(private val sampleRate: Int) : Sampler {
 //    override fun getAttributes(): Attributes {
 //        return attributes
 //    }
-//}
+// }

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSamplerTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSamplerTest.kt
@@ -14,7 +14,6 @@ import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
 class HoneycombDeterministicSamplerTest(private val args: TestArguments) {
-
     companion object {
         @JvmStatic
         @Parameters

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSamplerTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombDeterministicSamplerTest.kt
@@ -1,0 +1,44 @@
+package io.honeycomb.opentelemetry.android
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.TraceId
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.data.LinkData
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+class HoneycombDeterministicSamplerTest(private val args: TestArguments) {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun data(): List<TestArguments> {
+            return listOf(
+                TestArguments(0, SamplingDecision.DROP),
+                TestArguments(1, SamplingDecision.RECORD_AND_SAMPLE),
+                TestArguments(10, SamplingDecision.RECORD_AND_SAMPLE),
+                TestArguments(100, SamplingDecision.RECORD_AND_SAMPLE),
+            )
+        }
+    }
+
+    @Test
+    fun testSampler() {
+        // static trace id to ensure the inner traceIdRatio sampler always samples.
+        val traceId = TraceId.fromLongs(10L, 10L)
+        val context = Context.root()
+
+        val sampler = HoneycombDeterministicSampler(args.rate)
+        val result = sampler.shouldSample(context, traceId, "test", SpanKind.CLIENT, Attributes.empty(), emptyList<LinkData>().toMutableList())
+
+        assertEquals("[rate: ${args.rate}] expected: ${args.decision} but was: ${result.decision}", args.decision, result.decision)
+    }
+}
+
+data class TestArguments(val rate: Int, val decision: SamplingDecision)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ coreKtx = "1.13.1"
 desugarLibs = "2.1.2"
 espressoCore = "3.6.1"
 junit = "4.13.2"
+junitParams = "5.8.2"
 junitVersion = "1.2.1"
 kotlin = "1.9.0"
 lifecycleRuntimeKtx = "2.8.3"
@@ -52,6 +53,7 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarLibs" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitParams"}
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 opentelemetry-android-agent = { module = "io.opentelemetry.android:android-agent", version.ref = "opentelemetryAndroid" }


### PR DESCRIPTION
## Short description of the changes
Adds a deterministic sampler, similar to other Honeycomb distro. Heavily based on https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/17

That PR never actually _used_ the Sampler; I'm not sure if we need to make changes to HoneycombOptions / somewhere else in the initialization process to actually make use of this. 

## How to verify that this has the expected result
- [x] unit tests