### PR TITLE
docs: Include available config options in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ To manually send a span:
     span?.end()
 ```
 
+## Configuration Options
+
+| Option               | Type                                            | Required? | Description                                                                                                                                 |
+|----------------------|-------------------------------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `apiKey`             | String                                          | Yes       | Default [Honeycomb API Key](https://docs.honeycomb.io/working-with-your-data/settings/api-keys/) to use to send data directly to Honeycomb. |
+| `tracesApiKey`       | String                                          | No        | Dedicated API Key to use when sending traces.                                                                                               |
+| `metricsApiKey`      | String                                          | No        | Dedicated API Key to use when sending metrics.                                                                                              |
+| `logsApiKey`         | String                                          | No        | Dedicated API Key to use when sending logs.                                                                                                 |
+| `dataset`            | String                                          | No        | Name of Honeycomb dataset to send traces to. Required if sending to a classic Honeycomb environment.                                        |
+| `metricsDataset`     | String                                          | No        | Name of Honeycomb dataset to send metrics to, instead of `dataset`.                                                                         |
+| `apiEndpoint`        | String                                          | No        | API endpoint to send data to.                                                                                                               |
+| `tracesEndpoint`     | String                                          | No        | API endpoint to send traces to. Overrides `apiEndpoint` for trace data.                                                                     |
+| `metricsEndpoint`    | String                                          | No        | API endpoint to send metrics to. Overrides `apiEndpoint` for metrics data.                                                                  |
+| `logsEndpoint`       | String                                          | No        | API endpoint to send trace to. Overrides `apiEndpoint` for logs data.                                                                       |
+| `sampleRate`         | Int                                             | No        | Sample rate to apply (ie. a value of `40` means 1 in 40 traces will be exported).                                                           |
+| `debug`              | Boolean                                         | No        | Enable debug logging.                                                                                                                       |
+| `serviceName`        | String?                                         | No        | Name of Honeycomb service to send data to.                                                                                                  |
+| `resourceAttributes` | Map<String, String>                             | No        | Attributes to attach to outgoing resources.                                                                                                 |
+| `headers`            | Map<String, String>                             | No        | Headers to include on exported data.                                                                                                        |
+| `tracesHeaders`      | Map<String, String>                             | No        | Headers to add to exported trace data.                                                                                                      |
+| `metricsHeaders`     | Map<String, String>                             | No        | Headers to add to exported metrics data.                                                                                                    |
+| `logsHeaders`        | Map<String, String>                             | No        | Headers to add to exported logs data.                                                                                                       |
+| `timeout`            | Duration                                        | No        | Timeout used by exporter when sending data.                                                                                                 |
+| `tracesTimeout`      | Duration                                        | No        | Timeout used by traces exporter. Overrides `timeout` for trace data.                                                                        |
+| `metricsTimeout`     | Duration                                        | No        | Timeout used by metrics exporter. Overrides `timeout` for metrics data.                                                                     |
+| `logsTimeout`        | Duration                                        | No        | Timeout used by logs exporter. Overrides `timeout` for logs data.                                                                           |
+| `protocol`           | io.honeycomb.opentelemetry.android.OtlpProtocol | No        | Protocol to use when sending data.                                                                                                          |
+| `tracesProtocol`     | io.honeycomb.opentelemetry.android.OtlpProtocol | No        | Overrides `protocol` for trace data.                                                                                                        |
+| `metricsProtocol`    | io.honeycomb.opentelemetry.android.OtlpProtocol | No        | Overrides `protocol` for metrics data.                                                                                                      |
+| `logsProtocol`       | io.honeycomb.opentelemetry.android.OtlpProtocol | No        | Overrides `protocol` for logs data.                                                                                                         |
+
+
 ## Auto-instrumentation
 
 The following auto-instrumentation libraries are automatically included:

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -26,13 +26,6 @@ private const val OTEL_SERVICE_NAME_KEY = "OTEL_SERVICE_NAME"
 private const val OTEL_SERVICE_NAME_DEFAULT = "unknown_service"
 private const val OTEL_RESOURCE_ATTRIBUTES_KEY = "OTEL_RESOURCE_ATTRIBUTES"
 
-private const val OTEL_TRACES_SAMPLER_KEY = "OTEL_TRACES_SAMPLER"
-private const val OTEL_TRACES_SAMPLER_DEFAULT = "parentbased_always_on"
-private const val OTEL_TRACES_SAMPLER_ARG_KEY = "OTEL_TRACES_SAMPLER_ARG"
-
-private const val OTEL_PROPAGATORS_KEY = "OTEL_PROPAGATORS"
-private const val OTEL_PROPAGATORS_DEFAULT = "tracecontext,baggage"
-
 private const val OTEL_TRACES_EXPORTER_KEY = "OTEL_TRACES_EXPORTER"
 private const val OTEL_METRICS_EXPORTER_KEY = "OTEL_METRICS_EXPORTER"
 private const val OTEL_LOGS_EXPORTER_KEY = "OTEL_METRICS_EXPORTER"
@@ -161,9 +154,6 @@ data class HoneycombOptions(
     val debug: Boolean,
     val serviceName: String,
     val resourceAttributes: Map<String, String>,
-    val tracesSampler: String,
-    val tracesSamplerArg: String?,
-    val propagators: String,
     val tracesHeaders: Map<String, String>,
     val metricsHeaders: Map<String, String>,
     val logsHeaders: Map<String, String>,
@@ -193,9 +183,6 @@ data class HoneycombOptions(
 
         private var serviceName: String? = null
         private var resourceAttributes: Map<String, String> = mapOf()
-        private var tracesSampler: String = OTEL_TRACES_SAMPLER_DEFAULT
-        private var tracesSamplerArg: String? = null
-        private var propagators: String = OTEL_PROPAGATORS_DEFAULT
 
         private var headers: Map<String, String> = mapOf()
         private var tracesHeaders: Map<String, String> = mapOf()
@@ -248,9 +235,6 @@ data class HoneycombOptions(
             debug = source.getBoolean(DEBUG_KEY) ?: debug
             serviceName = source.getString(OTEL_SERVICE_NAME_KEY) ?: serviceName
             resourceAttributes = source.getKeyValueList(OTEL_RESOURCE_ATTRIBUTES_KEY)
-            tracesSampler = source.getString(OTEL_TRACES_SAMPLER_KEY) ?: tracesSampler
-            tracesSamplerArg = source.getString(OTEL_TRACES_SAMPLER_ARG_KEY)
-            propagators = source.getString(OTEL_PROPAGATORS_KEY) ?: propagators
             headers = source.getKeyValueList(OTEL_EXPORTER_OTLP_HEADERS_KEY)
             tracesHeaders = source.getKeyValueList(OTEL_EXPORTER_OTLP_TRACES_HEADERS_KEY)
             metricsHeaders = source.getKeyValueList(OTEL_EXPORTER_OTLP_METRICS_HEADERS_KEY)
@@ -332,21 +316,6 @@ data class HoneycombOptions(
 
         fun setResourceAttributes(resources: Map<String, String>): Builder {
             resourceAttributes = resources
-            return this
-        }
-
-        fun setTracesSampler(sampler: String): Builder {
-            tracesSampler = sampler
-            return this
-        }
-
-        fun setTracesSamplerArg(arg: String?): Builder {
-            tracesSamplerArg = arg
-            return this
-        }
-
-        fun setPropagators(propagators: String): Builder {
-            this.propagators = propagators
             return this
         }
 
@@ -513,9 +482,6 @@ data class HoneycombOptions(
                 debug,
                 serviceName,
                 resourceAttributes,
-                tracesSampler,
-                tracesSamplerArg,
-                propagators,
                 tracesHeaders,
                 metricsHeaders,
                 logsHeaders,

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -65,10 +65,6 @@ class HoneycombOptionsUnitTest {
             options.resourceAttributes,
         )
 
-        assertEquals("parentbased_always_on", options.tracesSampler)
-        assertNull(options.tracesSamplerArg)
-        assertEquals("tracecontext,baggage", options.propagators)
-
         assertEquals("https://api.honeycomb.io:443/v1/traces", options.tracesEndpoint)
         assertEquals("https://api.honeycomb.io:443/v1/metrics", options.metricsEndpoint)
         assertEquals("https://api.honeycomb.io:443/v1/logs", options.logsEndpoint)
@@ -101,9 +97,6 @@ class HoneycombOptionsUnitTest {
                 "HONEYCOMB_API_KEY" to "key",
                 "OTEL_SERVICE_NAME" to "",
                 "OTEL_RESOURCE_ATTRIBUTES" to "",
-                "OTEL_TRACES_SAMPLER" to "",
-                "OTEL_TRACES_SAMPLER_ARG" to "",
-                "OTEL_PROPAGATORS" to "",
                 "OTEL_EXPORTER_OTLP_HEADERS" to "",
                 "OTEL_EXPORTER_OTLP_TIMEOUT" to null,
                 "OTEL_EXPORTER_OTLP_PROTOCOL" to "",
@@ -120,10 +113,6 @@ class HoneycombOptionsUnitTest {
             ),
             options.resourceAttributes,
         )
-
-        assertEquals("parentbased_always_on", options.tracesSampler)
-        assertNull(options.tracesSamplerArg)
-        assertEquals("tracecontext,baggage", options.propagators)
 
         assertEquals("https://api.honeycomb.io:443/v1/traces", options.tracesEndpoint)
         assertEquals("https://api.honeycomb.io:443/v1/metrics", options.metricsEndpoint)
@@ -155,9 +144,6 @@ class HoneycombOptionsUnitTest {
                 "HONEYCOMB_API_ENDPOINT" to "http://example.com:1234",
                 "OTEL_SERVICE_NAME" to "service",
                 "OTEL_RESOURCE_ATTRIBUTES" to "resource=aaa",
-                "OTEL_TRACES_SAMPLER" to "sampler",
-                "OTEL_TRACES_SAMPLER_ARG" to "arg",
-                "OTEL_PROPAGATORS" to "propagators",
                 "OTEL_EXPORTER_OTLP_HEADERS" to "header=bbb",
                 "OTEL_EXPORTER_OTLP_TIMEOUT" to 30000,
                 "OTEL_EXPORTER_OTLP_PROTOCOL" to "http/json",
@@ -174,10 +160,6 @@ class HoneycombOptionsUnitTest {
             ),
             options.resourceAttributes,
         )
-
-        assertEquals("sampler", options.tracesSampler)
-        assertEquals("arg", options.tracesSamplerArg)
-        assertEquals("propagators", options.propagators)
 
         assertEquals("http://example.com:1234/v1/traces", options.tracesEndpoint)
         assertEquals("http://example.com:1234/v1/metrics", options.metricsEndpoint)
@@ -219,9 +201,6 @@ class HoneycombOptionsUnitTest {
                 "DEBUG" to true,
                 "OTEL_SERVICE_NAME" to "service",
                 "OTEL_RESOURCE_ATTRIBUTES" to "resource=aaa",
-                "OTEL_TRACES_SAMPLER" to "sampler",
-                "OTEL_TRACES_SAMPLER_ARG" to "arg",
-                "OTEL_PROPAGATORS" to "propagators",
                 "OTEL_EXPORTER_OTLP_TIMEOUT" to 30000,
                 "OTEL_EXPORTER_OTLP_PROTOCOL" to "http/json",
                 "OTEL_EXPORTER_OTLP_TRACES_HEADERS" to "header=ttt",
@@ -247,10 +226,6 @@ class HoneycombOptionsUnitTest {
             ),
             options.resourceAttributes,
         )
-
-        assertEquals("sampler", options.tracesSampler)
-        assertEquals("arg", options.tracesSamplerArg)
-        assertEquals("propagators", options.propagators)
 
         assertEquals("http://traces.example.com:1234", options.tracesEndpoint)
         assertEquals("http://metrics.example.com:1234", options.metricsEndpoint)
@@ -312,9 +287,6 @@ class HoneycombOptionsUnitTest {
                 .setDebug(true)
                 .setServiceName("service")
                 .setResourceAttributes(mapOf("resource" to "aaa"))
-                .setTracesSampler("sampler")
-                .setTracesSamplerArg("arg")
-                .setPropagators("propagators")
                 .setTracesTimeout(40.seconds)
                 .setMetricsTimeout(50.seconds)
                 .setLogsTimeout(60.seconds)
@@ -337,10 +309,6 @@ class HoneycombOptionsUnitTest {
             ),
             options.resourceAttributes,
         )
-
-        assertEquals("sampler", options.tracesSampler)
-        assertEquals("arg", options.tracesSamplerArg)
-        assertEquals("propagators", options.propagators)
 
         assertEquals("http://traces.example.com:1234", options.tracesEndpoint)
         assertEquals("http://metrics.example.com:1234", options.metricsEndpoint)
@@ -398,9 +366,6 @@ class HoneycombOptionsUnitTest {
                 .setDebug(true)
                 .setServiceName("service")
                 .setResourceAttributes(mapOf("resource" to "aaa"))
-                .setTracesSampler("sampler")
-                .setTracesSamplerArg("arg")
-                .setPropagators("propagators")
                 .setTimeout(30.seconds)
                 .setHeaders(mapOf("header" to "hhh"))
                 .setProtocol(OtlpProtocol.HTTP_JSON)
@@ -417,10 +382,6 @@ class HoneycombOptionsUnitTest {
             ),
             options.resourceAttributes,
         )
-
-        assertEquals("sampler", options.tracesSampler)
-        assertEquals("arg", options.tracesSamplerArg)
-        assertEquals("propagators", options.propagators)
 
         assertEquals("http://api.example.com:1234/v1/traces", options.tracesEndpoint)
         assertEquals("http://api.example.com:1234/v1/metrics", options.metricsEndpoint)


### PR DESCRIPTION
## Which problem is this PR solving?
Lets people know what config options they can pass

## Short description of the changes
- deleted `propagator`, `tracesSampler`, and `tracesSamplerArg` options as they were not used anywhere.
- documented the remaining options

## How to verify that this has the expected result
Read the docs, everything makes sense

---

~~- [ ] Changelog is updated~~ N/A
