### PR TITLE
feat: add `addSpanProcessor()` api for custom span processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.
+
 ## v0.0.4-alpha
 
 * feat: Add deterministic sampler (configurable through the `sampleRate` option)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/CompositeSpanProcessor.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/CompositeSpanProcessor.kt
@@ -5,14 +5,17 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
 
-class CompositeSpanProcessor: SpanProcessor {
+class CompositeSpanProcessor : SpanProcessor {
     var spanProcessors: MutableList<SpanProcessor> = ArrayList()
 
     fun addSpanProcessor(spanProcessor: SpanProcessor) {
         this.spanProcessors.add(spanProcessor)
     }
 
-    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+    override fun onStart(
+        parentContext: Context,
+        span: ReadWriteSpan,
+    ) {
         for (spanProcessor in spanProcessors) {
             spanProcessor.onStart(parentContext, span)
         }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/CompositeSpanProcessor.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/CompositeSpanProcessor.kt
@@ -1,0 +1,34 @@
+package io.honeycomb.opentelemetry.android
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+
+class CompositeSpanProcessor: SpanProcessor {
+    var spanProcessors: MutableList<SpanProcessor> = ArrayList()
+
+    fun addSpanProcessor(spanProcessor: SpanProcessor) {
+        this.spanProcessors.add(spanProcessor)
+    }
+
+    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+        for (spanProcessor in spanProcessors) {
+            spanProcessor.onStart(parentContext, span)
+        }
+    }
+
+    override fun isStartRequired(): Boolean {
+        return spanProcessors.any { it.isStartRequired }
+    }
+
+    override fun onEnd(span: ReadableSpan) {
+        for (spanProcessor in spanProcessors) {
+            spanProcessor.onEnd(span)
+        }
+    }
+
+    override fun isEndRequired(): Boolean {
+        return spanProcessors.any { it.isEndRequired }
+    }
+}

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -70,7 +70,12 @@ class Honeycomb {
                 .setResource(resource)
                 .addSpanExporterCustomizer { traceExporter }
                 .addTracerProviderCustomizer { builder, _ ->
-                    builder.addSpanProcessor(BaggageSpanProcessor.allowAllBaggageKeys())
+                    val spanProcessor = CompositeSpanProcessor()
+                    spanProcessor.addSpanProcessor(BaggageSpanProcessor.allowAllBaggageKeys())
+                    options.spanProcessor?.let {
+                        spanProcessor.addSpanProcessor(options.spanProcessor)
+                    }
+                    builder.addSpanProcessor(spanProcessor)
                     builder.setSampler(HoneycombDeterministicSampler(options.sampleRate))
                 }
                 .addLogRecordExporterCustomizer { logsExporter }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -2,6 +2,7 @@ package io.honeycomb.opentelemetry.android
 
 import android.content.Context
 import android.os.Build
+import io.opentelemetry.sdk.trace.SpanProcessor
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -150,6 +151,7 @@ data class HoneycombOptions(
     val tracesEndpoint: String,
     val metricsEndpoint: String,
     val logsEndpoint: String,
+    val spanProcessor: SpanProcessor?,
     val sampleRate: Int,
     val debug: Boolean,
     val serviceName: String,
@@ -178,6 +180,7 @@ data class HoneycombOptions(
         private var metricsEndpoint: String? = null
         private var logsEndpoint: String? = null
 
+        private var spanProcessor: SpanProcessor? = null
         private var sampleRate: Int = 1
         private var debug: Boolean = false
 
@@ -296,6 +299,11 @@ data class HoneycombOptions(
 
         fun setLogsApiEndpoint(endpoint: String): Builder {
             logsEndpoint = endpoint
+            return this
+        }
+
+        fun setSpanProcessor(spanProcessor: SpanProcessor): Builder {
+            this.spanProcessor = spanProcessor
             return this
         }
 
@@ -478,6 +486,7 @@ data class HoneycombOptions(
                 tracesEndpoint,
                 metricsEndpoint,
                 logsEndpoint,
+                spanProcessor,
                 sampleRate,
                 debug,
                 serviceName,

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/ExampleApp.kt
@@ -5,6 +5,7 @@ import io.honeycomb.opentelemetry.android.Honeycomb
 import io.honeycomb.opentelemetry.android.HoneycombOptions
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 
 class ExampleApp : Application() {
     var otelRum: OpenTelemetryRum? = null
@@ -20,6 +21,7 @@ class ExampleApp : Application() {
                 .setApiEndpoint("http://10.0.2.2:4318")
                 .setServiceName("android-test")
                 .setMetricsDataset("android-test-metrics")
+                .setSpanProcessor(SimpleSpanProcessor())
                 .setDebug(true)
                 .build()
 

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/SimpleSpanProcessor.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/SimpleSpanProcessor.kt
@@ -1,0 +1,22 @@
+package io.honeycomb.opentelemetry.android.example
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+
+class SimpleSpanProcessor: SpanProcessor {
+    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+        span.setAttribute("app.metadata", "extra metadata")
+    }
+
+    override fun isStartRequired(): Boolean {
+        return true
+    }
+
+    override fun onEnd(span: ReadableSpan) {}
+
+    override fun isEndRequired(): Boolean {
+        return false
+    }
+}

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/SimpleSpanProcessor.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/SimpleSpanProcessor.kt
@@ -5,8 +5,11 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
 
-class SimpleSpanProcessor: SpanProcessor {
-    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+class SimpleSpanProcessor : SpanProcessor {
+    override fun onStart(
+        parentContext: Context,
+        span: ReadWriteSpan,
+    ) {
         span.setAttribute("app.metadata", "extra metadata")
     }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -151,3 +151,7 @@ teardown_file() {
 "nested expensive text"
 "nested expensive view"'
 }
+
+@test "Span Processor gets added correctly" {
+    result=$(spans_received | jq ".attributes[] | select (.key == \"app.metadata\").value.stringValue" "app.metadata" string | uniq)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Based on https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/38

We need some API for clients to provide a custom span processor!

## Short description of the changes

- Adds a `.setSpanProcessor()` method to `HoneycombOptions`
    - `HoneycombOptions` has a `configureFromSource` method that reads values out of a key/vale dict, but I didn't update that. I wasn't sure how we'd pass in a full object with methods and such from such a dict. @beekhc let me know if you have ideas or if you think this is ok.
- Use that when setting up the SDK
- Adds an internal-only CompositeSpanProcessor that allows for multiple span processors
    - should we expose this as well? it might be useful

## How to verify that this has the expected result
- [x] smoke tests pass

---

- [x] Changelog is updated
