### PR TITLE
chore: use reverse url notation for instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Update instrumentation names to use reverse url notation (`io.honeycomb.instrumentation.*`) instead of `@honeycombio/instrumentation-*` notation.
+* Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation.
 
 ## v0.0.5-alpha
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update instrumentation names to use reverse url notation (`io.honeycomb.instrumentation.*`) instead of `@honeycombio/instrumentation-*` notation.
+
 ## v0.0.5-alpha
 
 * Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.

--- a/compose/src/main/java/io/honeycomb/opentelemetry/android/compose/HoneycombInstrumentedComposable.kt
+++ b/compose/src/main/java/io/honeycomb/opentelemetry/android/compose/HoneycombInstrumentedComposable.kt
@@ -27,7 +27,7 @@ fun HoneycombInstrumentedComposable(
     }
 
     val otelRum = LocalOpenTelemetryRum.current!!.openTelemetry
-    val tracer = otelRum.tracerProvider.tracerBuilder("io.honeycomb.instrumentation.view").build()
+    val tracer = otelRum.tracerProvider.tracerBuilder("io.honeycomb.view").build()
     val span =
         tracer
             .spanBuilder("View Render")

--- a/compose/src/main/java/io/honeycomb/opentelemetry/android/compose/HoneycombInstrumentedComposable.kt
+++ b/compose/src/main/java/io/honeycomb/opentelemetry/android/compose/HoneycombInstrumentedComposable.kt
@@ -27,7 +27,7 @@ fun HoneycombInstrumentedComposable(
     }
 
     val otelRum = LocalOpenTelemetryRum.current!!.openTelemetry
-    val tracer = otelRum.tracerProvider.tracerBuilder("io.honeycomb.render-instrumentation").build()
+    val tracer = otelRum.tracerProvider.tracerBuilder("io.honeycomb.instrumentation.view").build()
     val span =
         tracer
             .spanBuilder("View Render")

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
@@ -15,7 +15,7 @@ import io.opentelemetry.api.baggage.Baggage
 
 private fun onSendSpan(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
-    val tracer = otel?.getTracer("@honeycombio/smoke-test")
+    val tracer = otel?.getTracer("io.honeycomb.smoke-test")
     val baggage =
         Baggage.builder()
             .put("baggage-key", "baggage-value")
@@ -29,7 +29,7 @@ private fun onSendSpan(otelRum: OpenTelemetryRum?) {
 
 private fun onSendMetrics(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
-    val meter = otel?.getMeter("@honeycombio/smoke-test")
+    val meter = otel?.getMeter("io.honeycomb.smoke-test")
     val counter = meter?.counterBuilder("smoke-test.metric.int")?.build()
 
     counter?.add(1)

--- a/interaction/src/main/java/io/honeycomb/opentelemetry/android/interaction/WindowInstrumentation.kt
+++ b/interaction/src/main/java/io/honeycomb/opentelemetry/android/interaction/WindowInstrumentation.kt
@@ -26,7 +26,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.trace.Span
 import kotlin.math.roundToInt
 
-private const val INSTRUMENTATION_NAME = "io.honeycomb.instrumentation.ui"
+private const val INSTRUMENTATION_NAME = "io.honeycomb.ui"
 
 enum class TouchEventType(val spanName: String) {
     TOUCH_BEGAN("Touch Began"),

--- a/interaction/src/main/java/io/honeycomb/opentelemetry/android/interaction/WindowInstrumentation.kt
+++ b/interaction/src/main/java/io/honeycomb/opentelemetry/android/interaction/WindowInstrumentation.kt
@@ -26,7 +26,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.trace.Span
 import kotlin.math.roundToInt
 
-private const val INSTRUMENTATION_NAME = "@honeycombio/instrumentation-ui"
+private const val INSTRUMENTATION_NAME = "io.honeycomb.instrumentation.ui"
 
 enum class TouchEventType(val spanName: String) {
     TOUCH_BEGAN("Touch Began"),

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -3,7 +3,7 @@
 load test_helpers/utilities
 
 CONTAINER_NAME="android-test"
-SMOKE_TEST_SCOPE="@honeycombio/smoke-test"
+SMOKE_TEST_SCOPE="io.honeycomb.smoke-test"
 
 setup_file() {
   echo "# 🚧 preparing test" >&3
@@ -105,16 +105,16 @@ teardown_file() {
 }
 
 @test "UI touch events are captured" {
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "Touch Began" "example_button")
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "Touch Ended" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "Touch Began" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "Touch Ended" "example_button")
 }
 
 @test "UI click events are captured" {
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-ui" "click" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "click" "example_button")
 }
 
 @test "UI touch events have all attributes" {
-    span=$(spans_on_view_named "@honeycombio/instrumentation-ui" "click" "example_button")
+    span=$(spans_on_view_named "io.honeycomb.instrumentation.ui" "click" "example_button")
 
     name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
     assert_equal "$name" '"example_button"'

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -137,12 +137,12 @@ teardown_file() {
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "io.honeycomb.render-instrumentation" | sort | uniq -c | tr -s ' ')
+  result=$(span_names_for "io.honeycomb.instrumentation.view" | sort | uniq -c | tr -s ' ')
   assert_equal "$result" ' 7 "View Body"
  7 "View Render"'
 
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "io.honeycomb.render-instrumentation" "View Render" "view.name" string | sort | tr -s ' ')
+  total_duration=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "view.name" string | sort | tr -s ' ')
   assert_equal "$total_duration" '"expensive text 1"
 "expensive text 2"
 "expensive text 3"

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -105,16 +105,16 @@ teardown_file() {
 }
 
 @test "UI touch events are captured" {
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "Touch Began" "example_button")
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "Touch Ended" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.ui" "Touch Began" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.ui" "Touch Ended" "example_button")
 }
 
 @test "UI click events are captured" {
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.ui" "click" "example_button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.ui" "click" "example_button")
 }
 
 @test "UI touch events have all attributes" {
-    span=$(spans_on_view_named "io.honeycomb.instrumentation.ui" "click" "example_button")
+    span=$(spans_on_view_named "io.honeycomb.ui" "click" "example_button")
 
     name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
     assert_equal "$name" '"example_button"'
@@ -137,12 +137,12 @@ teardown_file() {
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "io.honeycomb.instrumentation.view" | sort | uniq -c | tr -s ' ')
+  result=$(span_names_for "io.honeycomb.view" | sort | uniq -c | tr -s ' ')
   assert_equal "$result" ' 7 "View Body"
  7 "View Render"'
 
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "view.name" string | sort | tr -s ' ')
+  total_duration=$(attribute_for_span_key "io.honeycomb.view" "View Render" "view.name" string | sort | tr -s ' ')
   assert_equal "$total_duration" '"expensive text 1"
 "expensive text 2"
 "expensive text 3"


### PR DESCRIPTION
## Which problem is this PR solving?
`@honeycombio/` naming is a web convention. This PR switches it up to reverse url notation.

## Short description of the changes
- Changed instrumentation names. I went with `io.honeycomb.instrumentation.*` notation, where the last chunk is a `kebab-case` name for the instrumentation.
- Changed smoke tests to match

This PR required far fewer changes than the accompanying iOS PR (https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/40), mostly due to the fact that we don't have as much of our own instrumentations on Android?

## How to verify that this has the expected result
Smoke tests still pass.

---

- [x] Changelog is updated
