### PR TITLE
refactor: Change dependencies from "agent" to "core" to enable build-time auto-instrumentation selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * feat: Add logException function for manual error reporting
+* refactor: Change dependencies to require users to explicitly include auto-instrumentation.
 * cleanup: Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation
 
 ## v0.0.5-alpha

--- a/README.md
+++ b/README.md
@@ -85,15 +85,18 @@ To manually send a span:
 
 ## Auto-instrumentation
 
-The following auto-instrumentation libraries are automatically included:
+To enable all OpenTelemetry auto-instrumentation, simply include `android-agent` as a dependency:
 * [`io.opentelemetry.android:android-agent`](https://github.com/open-telemetry/opentelemetry-android/tree/main)
+
+If you want to pick and choose which auto-instrumentation to include, you can instead add dependencies for whichever components you would like:
 * [`io.opentelemetry.android:instrumentation-activity`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/activity)
 * [`io.opentelemetry.android:instrumentation-anr`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/anr)
 * [`io.opentelemetry.android:instrumentation-crash`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/crash)
+* [`io.opentelemetry.android:instrumentation-fragment`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/fragment)
 * [`io.opentelemetry.android:instrumentation-slowrendering`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/slowrendering)
 
 The following additional auto-instrumentation is implemented in this library:
-* UI interaction in XML-based Activities.
+* `honeycomb-opentelemetry-android-interaction` &mdash; UI interaction in XML-based Activities.
 
 ### Activity Lifecycle Instrumentation
 

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -70,11 +70,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.auto.service.annotations)
-    implementation(libs.instrumentation.activity)
-    implementation(libs.instrumentation.anr)
-    implementation(libs.instrumentation.crash)
-    implementation(libs.instrumentation.slowrendering)
-    implementation(libs.opentelemetry.android.agent)
+    implementation(libs.opentelemetry.android.core)
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.logging.otlp)
@@ -89,7 +85,6 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.opentelemetry.api)
     androidTestImplementation(libs.opentelemetry.sdk)
-    androidTestImplementation(libs.opentelemetry.android.agent)
 }
 
 apply("${project.rootDir}/spotless.gradle")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -70,16 +70,11 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.auto.service.annotations)
-    implementation(libs.instrumentation.activity)
-    implementation(libs.instrumentation.anr)
-    implementation(libs.instrumentation.crash)
-    implementation(libs.instrumentation.slowrendering)
-    implementation(libs.opentelemetry.android.agent)
+    implementation(libs.opentelemetry.android.core)
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.logging.otlp)
     implementation(libs.opentelemetry.exporter.otlp)
-    implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.baggage.processor)
 
     testImplementation(libs.junit)
@@ -90,7 +85,6 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.opentelemetry.api)
     androidTestImplementation(libs.opentelemetry.sdk)
-    androidTestImplementation(libs.opentelemetry.android.agent)
 }
 
 apply("${project.rootDir}/spotless.gradle")

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -67,9 +67,14 @@ dependencies {
     // This is required by opentelemetry-android.
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    implementation(libs.opentelemetry.android.agent)
+    implementation(libs.opentelemetry.android.core)
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
+    implementation(libs.instrumentation.activity)
+    implementation(libs.instrumentation.anr)
+    implementation(libs.instrumentation.crash)
+    implementation(libs.instrumentation.fragment)
+    implementation(libs.instrumentation.slowrendering)
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
@@ -84,6 +89,7 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material3)
     implementation(libs.material)
+
     implementation(project(":compose"))
     implementation(project(":core"))
     implementation(project(":interaction"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,10 +56,11 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitParams"}
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
-opentelemetry-android-agent = { module = "io.opentelemetry.android:android-agent", version.ref = "opentelemetryAndroid" }
+opentelemetry-android-core = { module = "io.opentelemetry.android:core", version.ref = "opentelemetryAndroid" }
 instrumentation-activity = { module = "io.opentelemetry.android:instrumentation-activity", version.ref = "opentelemetryAndroid"  }
 instrumentation-anr = { module = "io.opentelemetry.android:instrumentation-anr", version.ref = "opentelemetryAndroid"  }
 instrumentation-crash = { module = "io.opentelemetry.android:instrumentation-crash", version.ref = "opentelemetryAndroid"  }
+instrumentation-fragment = { module = "io.opentelemetry.android:instrumentation-fragment", version.ref = "opentelemetryAndroid"  }
 instrumentation-slowrendering = { module = "io.opentelemetry.android:instrumentation-slowrendering", version.ref = "opentelemetryAndroid"  }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/interaction/build.gradle.kts
+++ b/interaction/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
 
-    implementation(libs.opentelemetry.android.agent)
+    implementation(libs.opentelemetry.android.core)
 
     // This is required by opentelemetry-android.
     coreLibraryDesugaring(libs.desugar.jdk.libs)


### PR DESCRIPTION
## Which problem is this PR solving?

Our intention was that developers be able to decide which auto-instrumentation is included in their apps by choosing their dependencies. However, our SDK was depending on OTel's `android-agent` target, which has dependencies on all the common auto-instrumentation, resulting in it always being present.

## Short description of the changes

* Replaces dependency on `android-agent` with `core`, and adds the specific auto-instrumentation needed in the smoke tests.
* Updates README to show the options available for auto-instrumentation.

## How to verify that this has the expected result

I tested several scenarios:
1. If I remove the auto-instrumentation from the example dependency, the smoke tests fail, as expected.
2. If I change the auto-instrumentation in the example to just "android-agent", the smoke tests pass, as expected.
3. If I leave the auto-instrumentation listed explicitly as shown, the smoke tests pass, as expected.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
