### PR TITLE
docs: add docs and more features to manual exception api

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,35 @@ launch(Span.current().asContextElement()) {
 }
 ```
 
+### Manual Error Logging
+
+Exceptions may be recorded as Log records using the `log` method. This can be used for logging 
+any caught exceptions in your own code that will not be logged by our crash instrumentation.
+
+Below is an example of logging an Exception object using several custom attributes.
+
+```kotlin
+try {
+    // ...
+} catch (e: Exception) {
+    Honeycomb.logException(
+        otel,
+        e,
+        Attributes.of(
+            AttributeKey.stringKey("user.name"), "bufo",
+            AttributeKey.longKey("user.id"), 1
+        ),
+        Thread.currentThread())
+}
+```
+
+| Argument   | Type             | Is Required | Description                                                                       |
+|------------|------------------|-------------|-----------------------------------------------------------------------------------|
+| otel       | OpenTelemetryRum | true        | The exception itself. Attributes will be automatically added to the log record.   |
+| exception  | Throwable        | true        | The exception itself. Attributes will be automatically added to the log record.   |
+| attributes | Attributes       | false       | Additional attributes you would like to log along with the default ones provided. |
+| thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as an attribute.  |
+
 ### Android Compose
 #### Setup
 Android Compose instrumentation is included in a standalone library. Add the following to your dependencies in `build.gradle.kts`:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ launch(Span.current().asContextElement()) {
 
 ### Manual Error Logging
 
-Exceptions may be recorded as Log records using the `log` method. This can be used for logging 
+Exceptions may be recorded as Log records using the `logException` method. This can be used for logging
 any caught exceptions in your own code that will not be logged by our crash instrumentation.
 
 Below is an example of logging an Exception object using several custom attributes.

--- a/README.md
+++ b/README.md
@@ -229,10 +229,10 @@ try {
 
 | Argument   | Type             | Is Required | Description                                                                       |
 |------------|------------------|-------------|-----------------------------------------------------------------------------------|
-| otel       | OpenTelemetryRum | true        | The exception itself. Attributes will be automatically added to the log record.   |
+| otel       | OpenTelemetryRum | true        | The OpenTelemetryRum instance to use for logging.                                 |
 | exception  | Throwable        | true        | The exception itself. Attributes will be automatically added to the log record.   |
-| attributes | Attributes       | false       | Additional attributes you would like to log along with the default ones provided. |
-| thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as an attribute.  |
+| attributes | Attributes?      | false       | Additional attributes you would like to log along with the default ones provided. |
+| thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as attributes.    |
 
 ### Android Compose
 #### Setup

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -109,6 +109,7 @@ class Honeycomb {
         fun logException(
             otel: OpenTelemetryRum,
             throwable: Throwable,
+            attributes: Attributes? = null,
             thread: Thread? = null,
         ) {
             // TODO: It would be nice to include the common RuntimeDetailsExtractor, in order to
@@ -124,6 +125,10 @@ class Honeycomb {
                 Attributes.builder()
                     .put(EXCEPTION_STACKTRACE, stackTraceToString(throwable))
                     .put(EXCEPTION_TYPE, throwable.javaClass.name)
+
+            attributes?.let {
+                attributesBuilder.putAll(it)
+            }
 
             throwable.message?.let {
                 attributesBuilder.put(EXCEPTION_MESSAGE, it)

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
@@ -52,10 +52,12 @@ private fun onLogException(otelRum: OpenTelemetryRum?) {
                 otelRum,
                 e,
                 Attributes.of(
-                    AttributeKey.stringKey("user.name"), "bufo",
-                    AttributeKey.longKey("user.id"), 1
+                    AttributeKey.stringKey("user.name"),
+                    "bufo",
+                    AttributeKey.longKey("user.id"),
+                    1,
                 ),
-                Thread.currentThread()
+                Thread.currentThread(),
             )
         }
     }

--- a/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
+++ b/example/src/main/java/io/honeycomb/opentelemetry/android/example/CorePlayground.kt
@@ -13,6 +13,8 @@ import io.honeycomb.opentelemetry.android.Honeycomb
 import io.honeycomb.opentelemetry.android.example.ui.theme.HoneycombOpenTelemetryAndroidTheme
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.api.baggage.Baggage
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 
 private fun onSendSpan(otelRum: OpenTelemetryRum?) {
     val otel = otelRum?.openTelemetry
@@ -46,7 +48,15 @@ private fun onLogException(otelRum: OpenTelemetryRum?) {
         throw RuntimeException("This exception was intentional.")
     } catch (e: Exception) {
         if (otelRum != null) {
-            Honeycomb.logException(otelRum, e)
+            Honeycomb.logException(
+                otelRum,
+                e,
+                Attributes.of(
+                    AttributeKey.stringKey("user.name"), "bufo",
+                    AttributeKey.longKey("user.id"), 1
+                ),
+                Thread.currentThread()
+            )
         }
     }
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -106,6 +106,18 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.stacktrace" "string" \
     | grep "example.CorePlaygroundKt.onLogException")
   assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "thread.name" "string")
+  assert_equal "$result" '"main"'
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "thread.id" "int")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "user.name" "string")
+  assert_equal "$result" '"bufo"'
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "user.id" "int")
+  assert_equal "$result" '"1"'
 }
 
 @test "SDK detects slow renders" {


### PR DESCRIPTION
## Which problem is this PR solving?

1. We didn't have docs in the README for manual exception handling.
2. The manual exception API on Android was missing feature the iOS one has.

## Short description of the changes

This adds the missing features and adds docs.

## How to verify that this has the expected result

The smoke test is extended to check the new attributes.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
