### PR TITLE
rel: v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.0.6-alpha
+
 * feat: Add logException function for manual error reporting
 * refactor: Change dependencies to require users to explicitly include auto-instrumentation.
 * cleanup: Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v0.0.6-beta
+## v0.0.6
 
 * feat: Add logException function for manual error reporting
 * refactor: Change dependencies to require users to explicitly include auto-instrumentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v0.0.6-alpha
+## v0.0.6-beta
 
 * feat: Add logException function for manual error reporting
 * refactor: Change dependencies to require users to explicitly include auto-instrumentation.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on Android.
 Add the following dependencies to your `build.gradle.kts`:
 ```
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.6-alpha")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.6-beta")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on Android.
 Add the following dependencies to your `build.gradle.kts`:
 ```
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.6-beta")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.6")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on Android.
 
-**STATUS: this library is EXPERIMENTAL.** Data shapes are unstable and not safe for production. We are actively seeking feedback to ensure usability.
+**STATUS: this library is in BETA.** Data shapes are stable and safe for production. We are actively seeking feedback to ensure usability.
 
 ## Getting started
 
 Add the following dependencies to your `build.gradle.kts`:
 ```
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.5-alpha")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.6-alpha")
 }
 ```
 


### PR DESCRIPTION
Prepare 0.0.6 release.

Like the accompanying [swift](https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/60) release, this release also drops the experimental label from the readme and `-alpha` suffix from our version number.

- [x] CHANGELOG is updated
- [x] README is updated with documentation
