### PR TITLE
feat: install.id added to all spans

### DIFF
--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -1,6 +1,8 @@
 package io.honeycomb.opentelemetry.android
 
 import android.app.Application
+import android.os.Build
+import android.provider.Settings.Secure
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
@@ -29,6 +31,10 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_ID
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
 import io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
@@ -44,6 +50,17 @@ private fun createAttributes(dict: Map<String, String>): Attributes {
     for (entry in dict) {
         builder.put(entry.key, entry.value)
     }
+    return builder.build()
+}
+
+private fun getDeviceAttributes(): Attributes {
+    val builder = Attributes.builder()
+
+    builder.put(DEVICE_ID, Secure.ANDROID_ID)
+    builder.put(DEVICE_MODEL_NAME, Build.MODEL)
+    builder.put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
+    builder.put(DEVICE_MODEL_IDENTIFIER, Build.ID)
+
     return builder.build()
 }
 
@@ -80,6 +97,7 @@ class Honeycomb {
             val resource =
                 Resource.getDefault().toBuilder()
                     .putAll(createAttributes(options.resourceAttributes))
+                    .putAll(getDeviceAttributes())
                     .build()
 
             val rumConfig = OtelRumConfig()

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -57,9 +57,7 @@ private fun getDeviceAttributes(): Attributes {
     val builder = Attributes.builder()
 
     builder.put(DEVICE_ID, Secure.ANDROID_ID)
-    builder.put(DEVICE_MODEL_NAME, Build.MODEL)
     builder.put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
-    builder.put(DEVICE_MODEL_IDENTIFIER, Build.ID)
 
     return builder.build()
 }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -33,8 +33,6 @@ import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_ID
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
 import io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -20,8 +20,8 @@ teardown_file() {
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | sort | uniq)
   assert_equal "$result" '"device.manufacturer"
-"device.id"
 "device.manufacturer"
+"device.id"
 "device.model.identifier"
 "device.model.name"
 "honeycomb.distro.runtime_version"

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -20,6 +20,8 @@ teardown_file() {
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | sort | uniq)
   assert_equal "$result" '"device.manufacturer"
+"device.id"
+"device.manufacturer"
 "device.model.identifier"
 "device.model.name"
 "honeycomb.distro.runtime_version"

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -19,9 +19,8 @@ teardown_file() {
 
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | sort | uniq)
-  assert_equal "$result" '"device.manufacturer"
+  assert_equal "$result" '"device.id"
 "device.manufacturer"
-"device.id"
 "device.model.identifier"
 "device.model.name"
 "honeycomb.distro.runtime_version"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This adds `device.id` to emitted spans.

- Closes #<enter issue here>

## Short description of the changes

## How to verify that this has the expected result

Tested with smoke tests

---

- [X] CHANGELOG is updated
- [N/A] README is updated with documentation
