### PR TITLE
feat: Allow optional API key for custom endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* feat: Allow optional API key for custom endpoint
+
 ## v0.0.7
 
 * feat: install.id added to all spans
@@ -44,4 +46,3 @@
 
 * Initial release
 * Basic configuration helpers
-

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -2,9 +2,9 @@ package io.honeycomb.opentelemetry.android
 
 import android.content.Context
 import android.os.Build
-import android.webkit.URLUtil
 import io.opentelemetry.sdk.trace.SpanProcessor
 import java.net.URI
+import java.net.URISyntaxException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -91,13 +91,12 @@ private fun isClassicKey(key: String?): Boolean {
 }
 
 private fun isHoneycombEndpoint(endpoint: String): Boolean {
-    if (URLUtil.isValidUrl(endpoint)) {
+    try {
         val uri = URI(endpoint)
-
         return uri.host.endsWith(".honeycomb.io")
+    } catch (_: URISyntaxException) {
+        return false
     }
-
-    return false
 }
 
 /**

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -2,7 +2,9 @@ package io.honeycomb.opentelemetry.android
 
 import android.content.Context
 import android.os.Build
+import android.webkit.URLUtil
 import io.opentelemetry.sdk.trace.SpanProcessor
+import java.net.URI
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -75,13 +77,27 @@ private val INGEST_CLASSIC_KEY_REGEX = Regex("hc[a-z]ic_[a-z0-9]*")
 /**
  * Returns whether the passed in API key is classic or not.
  */
-private fun isClassicKey(key: String): Boolean {
+private fun isClassicKey(key: String?): Boolean {
+    if (key == null) {
+        return false
+    }
+
     return when (key.length) {
         0 -> false
         32 -> CLASSIC_KEY_REGEX.matches(key)
         64 -> INGEST_CLASSIC_KEY_REGEX.matches(key)
         else -> false
     }
+}
+
+private fun isHoneycombEndpoint(endpoint: String): Boolean {
+    if (URLUtil.isValidUrl(endpoint)) {
+        val uri = URI(endpoint)
+
+        return uri.host.endsWith(".honeycomb.io")
+    }
+
+    return false
 }
 
 /**
@@ -121,14 +137,15 @@ private fun getHoneycombEndpoint(
  * Gets the headers to use for a particular exporter.
  */
 private fun getHeaders(
-    apiKey: String,
+    apiKey: String?,
     dataset: String?,
     generalHeaders: Map<String, String>,
     signalHeaders: Map<String, String>,
 ): Map<String, String> {
     val otlpVersion = io.opentelemetry.android.BuildConfig.OTEL_ANDROID_VERSION
     val baseHeaders = mapOf("x-otlp-version" to otlpVersion)
-    val signalBaseHeaders = mutableMapOf("x-honeycomb-team" to apiKey)
+    val signalBaseHeaders = mutableMapOf<String, String>()
+    apiKey?.let { signalBaseHeaders["x-honeycomb-team"] = apiKey }
     dataset?.let { signalBaseHeaders["x-honeycomb-dataset"] = it }
 
     return baseHeaders + generalHeaders + signalBaseHeaders + signalHeaders
@@ -148,9 +165,9 @@ class HoneycombException(
  * https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
  */
 data class HoneycombOptions(
-    val tracesApiKey: String,
-    val metricsApiKey: String,
-    val logsApiKey: String,
+    val tracesApiKey: String?,
+    val metricsApiKey: String?,
+    val logsApiKey: String?,
     val dataset: String?,
     val metricsDataset: String?,
     val tracesEndpoint: String,
@@ -422,14 +439,6 @@ data class HoneycombOptions(
         }
 
         fun build(): HoneycombOptions {
-            // If any API key isn't set, consider it a fatal error.
-            val defaultApiKey: () -> String = {
-                if (apiKey == null) {
-                    throw HoneycombException("missing API key: call setApiKey()")
-                }
-                apiKey as String
-            }
-
             // Collect the non-exporter-specific values.
             val resourceAttributes = resourceAttributes.toMutableMap()
             // Any explicit service name overrides the one in the resource attributes.
@@ -469,9 +478,43 @@ data class HoneycombOptions(
                 "android",
             )
 
-            val tracesApiKey = this.tracesApiKey ?: defaultApiKey()
-            val metricsApiKey = this.metricsApiKey ?: defaultApiKey()
-            val logsApiKey = this.logsApiKey ?: defaultApiKey()
+            val tracesEndpoint =
+                getHoneycombEndpoint(
+                    this.tracesEndpoint,
+                    apiEndpoint,
+                    tracesProtocol ?: protocol,
+                    "v1/traces",
+                )
+            val metricsEndpoint =
+                getHoneycombEndpoint(
+                    this.metricsEndpoint,
+                    apiEndpoint,
+                    metricsProtocol ?: protocol,
+                    "v1/metrics",
+                )
+            val logsEndpoint =
+                getHoneycombEndpoint(
+                    this.logsEndpoint,
+                    apiEndpoint,
+                    logsProtocol ?: protocol,
+                    "v1/logs",
+                )
+
+            val tracesApiKey = this.tracesApiKey ?: this.apiKey
+            val metricsApiKey = this.metricsApiKey ?: this.apiKey
+            val logsApiKey = this.logsApiKey ?: this.apiKey
+
+            if (isHoneycombEndpoint(tracesEndpoint) && tracesApiKey == null) {
+                throw HoneycombException("missing API key: call setApiKey() or setTracesApiKey()")
+            }
+
+            if (isHoneycombEndpoint(metricsEndpoint) && metricsApiKey == null) {
+                throw HoneycombException("missing API key: call setApiKey() or setMetricsApiKey()")
+            }
+
+            if (isHoneycombEndpoint(logsEndpoint) && logsApiKey == null) {
+                throw HoneycombException("missing API key: call setApiKey() or setLogsApiKey()")
+            }
 
             val tracesHeaders =
                 getHeaders(
@@ -493,28 +536,6 @@ data class HoneycombOptions(
                     if (isClassicKey(tracesApiKey)) dataset else null,
                     headers,
                     this.logsHeaders,
-                )
-
-            val tracesEndpoint =
-                getHoneycombEndpoint(
-                    this.tracesEndpoint,
-                    apiEndpoint,
-                    tracesProtocol ?: protocol,
-                    "v1/traces",
-                )
-            val metricsEndpoint =
-                getHoneycombEndpoint(
-                    this.metricsEndpoint,
-                    apiEndpoint,
-                    metricsProtocol ?: protocol,
-                    "v1/metrics",
-                )
-            val logsEndpoint =
-                getHoneycombEndpoint(
-                    this.logsEndpoint,
-                    apiEndpoint,
-                    logsProtocol ?: protocol,
-                    "v1/logs",
                 )
 
             return HoneycombOptions(

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -891,4 +891,15 @@ class HoneycombOptionsUnitTest {
             HoneycombOptions.Builder(source).build()
         }
     }
+
+    @Test
+    fun options_noThrowsOnMissingApiKeyWithCustomEndpoint() {
+        val source =
+            HoneycombOptionsMapSource(
+                mapOf<String, Any?>(
+                    "HONEYCOMB_API_ENDPOINT" to "http://example.com:1234",
+                ),
+            )
+        HoneycombOptions.Builder(source).build()
+    }
 }

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -879,4 +879,16 @@ class HoneycombOptionsUnitTest {
             HoneycombOptions.Builder(source).build()
         }
     }
+
+    @Test
+    fun options_throwsOnMissingApiKey() {
+        val source =
+            HoneycombOptionsMapSource(
+                mapOf<String, Any?>(
+                ),
+            )
+        assertThrows(HoneycombException::class.java) {
+            HoneycombOptions.Builder(source).build()
+        }
+    }
 }

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -884,8 +884,7 @@ class HoneycombOptionsUnitTest {
     fun options_throwsOnMissingApiKey() {
         val source =
             HoneycombOptionsMapSource(
-                mapOf<String, Any?>(
-                ),
+                mapOf<String, Any?>(),
             )
         assertThrows(HoneycombException::class.java) {
             HoneycombOptions.Builder(source).build()


### PR DESCRIPTION
## Short description of the changes

If you are not sending directly to honeycomb and using some kind of pipeline involving refinery or collectors then you shouldn't need to provide the API key. 

This adds similar logic from the web SDK. https://github.com/honeycombio/honeycomb-opentelemetry-web/pull/477

It feels a little messy so please suggest a totally different way to do this if you can think of one 🙏 

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
