### PR TITLE
refactor: Switch to using android agent as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Honeycomb Android SDK changelog
 
 ## Unreleased
+refactor: Switch to using android agent as dependency
 
 ## v0.0.7
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -70,11 +70,7 @@ dependencies {
     implementation(libs.opentelemetry.android.core)
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
-    implementation(libs.instrumentation.activity)
-    implementation(libs.instrumentation.anr)
-    implementation(libs.instrumentation.crash)
-    implementation(libs.instrumentation.fragment)
-    implementation(libs.instrumentation.slowrendering)
+    implementation(libs.android.agent)
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ material = "1.12.0"
 mockitoCore = "4.11.0"
 mockitoKotlin = "4.1.0"
 okhttp = "4.12.0"
-opentelemetry = "1.49.0"
+opentelemetry = "1.43.0"
 opentelemetryAndroid = "0.8.0-alpha"
 opentelemetryBaggageProcessor = "1.42.0-alpha"
 opentelemetryInstrumentation = "2.9.0"
@@ -33,6 +33,7 @@ uiautomator = "2.4.0-alpha01"
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+android-agent = { module = "io.opentelemetry.android:android-agent", version.ref = "opentelemetryAndroid" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
@@ -54,11 +55,6 @@ auto-service-processor = { module = "com.google.auto.service:auto-service", vers
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarLibs" }
-instrumentation-activity = { module = "io.opentelemetry.android:instrumentation-activity", version.ref = "opentelemetryAndroid"  }
-instrumentation-anr = { module = "io.opentelemetry.android:instrumentation-anr", version.ref = "opentelemetryAndroid"  }
-instrumentation-crash = { module = "io.opentelemetry.android:instrumentation-crash", version.ref = "opentelemetryAndroid"  }
-instrumentation-fragment = { module = "io.opentelemetry.android:instrumentation-fragment", version.ref = "opentelemetryAndroid"  }
-instrumentation-slowrendering = { module = "io.opentelemetry.android:instrumentation-slowrendering", version.ref = "opentelemetryAndroid"  }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitParams"}
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes

Instead of explicitly listing instrumentation as dependencies, use the android agent dependency. This will help make sure we aren't missing any instrumentation (ex. startup)

## How to verify that this has the expected result
Tests pass

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
