### PR TITLE
maint: Increase dependabot.yml open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: gradle
     directory: /
+    open-pull-requests-limit: 15
     schedule:
       interval: weekly
     ignore:


### PR DESCRIPTION
Up the number of PRs dependabot can open for this repo, since 5 never seems to be enough, based on warnings in the dependabot logs.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-