### PR TITLE
fix: Device ID is now actual android ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Honeycomb Android SDK changelog
 
 ## Unreleased
+* fix: Device ID is now the android id and not the string `android_id`
 
 ## v0.0.10
 

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -1,7 +1,6 @@
 package io.honeycomb.opentelemetry.android
 
 import android.app.Application
-import android.content.Context
 import android.os.Build
 import android.provider.Settings.Secure
 import io.opentelemetry.android.OpenTelemetryRum
@@ -55,10 +54,10 @@ private fun createAttributes(dict: Map<String, String>): Attributes {
     return builder.build()
 }
 
-private fun getDeviceAttributes(appContext: Context): Attributes {
+private fun getDeviceAttributes(app: Application): Attributes {
     val builder = Attributes.builder()
 
-    builder.put(DEVICE_ID, Secure.getString(appContext.contentResolver, Secure.ANDROID_ID))
+    builder.put(DEVICE_ID, Secure.getString(app.applicationContext.contentResolver, Secure.ANDROID_ID))
     builder.put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
 
     return builder.build()
@@ -101,7 +100,7 @@ class Honeycomb {
                     .getDefault()
                     .toBuilder()
                     .putAll(createAttributes(options.resourceAttributes))
-                    .putAll(getDeviceAttributes(app.applicationContext))
+                    .putAll(getDeviceAttributes(app))
                     .build()
 
             val rumConfig = OtelRumConfig()

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -1,6 +1,7 @@
 package io.honeycomb.opentelemetry.android
 
 import android.app.Application
+import android.content.Context
 import android.os.Build
 import android.provider.Settings.Secure
 import io.opentelemetry.android.OpenTelemetryRum
@@ -54,10 +55,10 @@ private fun createAttributes(dict: Map<String, String>): Attributes {
     return builder.build()
 }
 
-private fun getDeviceAttributes(): Attributes {
+private fun getDeviceAttributes(appContext: Context): Attributes {
     val builder = Attributes.builder()
 
-    builder.put(DEVICE_ID, Secure.ANDROID_ID)
+    builder.put(DEVICE_ID, Secure.getString(appContext.contentResolver, Secure.ANDROID_ID))
     builder.put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
 
     return builder.build()
@@ -100,7 +101,7 @@ class Honeycomb {
                     .getDefault()
                     .toBuilder()
                     .putAll(createAttributes(options.resourceAttributes))
-                    .putAll(getDeviceAttributes())
+                    .putAll(getDeviceAttributes(app.applicationContext))
                     .build()
 
             val rumConfig = OtelRumConfig()

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -41,6 +41,9 @@ teardown_file() {
   result=$(resource_attribute_named "telemetry.sdk.language" "string" | uniq)
   assert_equal "$result" '"android"'
 
+  result=$(resource_attribute_named "device.id" "string" | uniq)
+  assert_not_empty_string "$result"
+
   assert_equal $(resource_attribute_named "service.name" "string" | uniq) '"android-test"'
   assert_equal $(resource_attribute_named "service.version" "string" | uniq) '"0.0.1"'
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
`device.id` was showing `android_id` instead of the actual android ID

- Closes #<enter issue here>

## Short description of the changes
Add a call to secure store to update to put the correct android ID in.

## How to verify that this has the expected result
- Automated tests added to ensure the device id is populated.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
