### PR TITLE
maint: switch to `api` dependency in build.gradle.kts

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -59,9 +59,9 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.auto.service.annotations)
-    implementation(libs.opentelemetry.android.core)
-    implementation(libs.opentelemetry.api)
-    implementation(libs.opentelemetry.sdk)
+    api(libs.opentelemetry.android.core)
+    api(libs.opentelemetry.api)
+    api(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.semconv)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.exporter.logging.otlp)

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -66,6 +66,11 @@ dependencies {
     // This is required by opentelemetry-android.
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
+    implementation(libs.opentelemetry.android.agent)
+    implementation(libs.opentelemetry.android.core)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.sdk)
+
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -66,11 +66,6 @@ dependencies {
     // This is required by opentelemetry-android.
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    implementation(libs.opentelemetry.android.agent)
-    implementation(libs.opentelemetry.android.core)
-    implementation(libs.opentelemetry.api)
-    implementation(libs.opentelemetry.sdk)
-
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## Which problem is this PR solving?
Cleaning up our dependency declarations

## Short description of the changes
Experimenting with `api` dependencies in our gradle build.

I am concerned about package/bundle sizes, but it looks like this change doesn't impact that much. 

Here are the built artifacts on current `main`:

```
$ ls -lh core/build/outputs/aar    
total 176
-rw-r--r--@ 1 mustafa  staff    43K Jun 18 11:29 core-debug.aar
-rw-r--r--@ 1 mustafa  staff    40K Jun 18 11:29 core-release.aar
$ ls -lh compose/build/outputs/aar 
total 32
-rw-r--r--@ 1 mustafa  staff   6.8K Jun 18 11:29 compose-debug.aar
-rw-r--r--@ 1 mustafa  staff   6.4K Jun 18 11:29 compose-release.aar
$ ls -lh interaction/build/outputs/aar
total 64
-rw-r--r--@ 1 mustafa  staff    15K Jun 18 11:30 interaction-debug.aar
-rw-r--r--@ 1 mustafa  staff    14K Jun 18 11:30 interaction-release.aar
```

```
$ ls -lh ~/.m2/repository/io/honeycomb/android/honeycomb-opentelemetry-android/0.0.0-DEVELOPMENT
total 168
-rw-r--r--@ 1 mustafa  staff    21K Jun 18 11:30 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT-sources.jar
-rw-r--r--@ 1 mustafa  staff    40K Jun 18 11:30 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.aar
-rw-r--r--@ 1 mustafa  staff   5.7K Jun 18 11:30 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.module
-rw-r--r--@ 1 mustafa  staff   4.6K Jun 18 11:30 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.pom
```

and with these changes:

```
$ ls -lh core/build/outputs/aar
total 176
-rw-r--r--@ 1 mustafa  staff    43K Jun 18 10:25 core-debug.aar
-rw-r--r--@ 1 mustafa  staff    40K Jun 18 10:25 core-release.aar
$ ls -lh compose/build/outputs/aar 
total 32
-rw-r--r--@ 1 mustafa  staff   6.8K Jun 18 10:25 compose-debug.aar
-rw-r--r--@ 1 mustafa  staff   6.4K Jun 18 10:25 compose-release.aar
$ ls -lh interaction/build/outputs/aar
total 64
-rw-r--r--@ 1 mustafa  staff    15K Jun 18 10:25 interaction-debug.aar
-rw-r--r--@ 1 mustafa  staff    14K Jun 18 10:26 interaction-release.aar
```

```
$ ls -lh ~/.m2/repository/io/honeycomb/android/honeycomb-opentelemetry-android/0.0.0-DEVELOPMENT
total 168
-rw-r--r--@ 1 mustafa  staff    21K Jun 17 16:52 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT-sources.jar
-rw-r--r--@ 1 mustafa  staff    40K Jun 17 16:52 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.aar
-rw-r--r--@ 1 mustafa  staff   5.7K Jun 17 16:52 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.module
-rw-r--r--@ 1 mustafa  staff   4.6K Jun 17 16:52 honeycomb-opentelemetry-android-0.0.0-DEVELOPMENT.pom
```

And on our internal test app, the size of the build doesn't change either:

using the latest version from maven central, the app comes out to 20 mb:
![image](https://github.com/user-attachments/assets/724e3369-09d6-49e2-91ea-66912992d76b)


using this version, built locally, the app comes out to 20 mb:
![image](https://github.com/user-attachments/assets/dc0d26d1-eddc-47ea-bbe0-3267115b1cf0)


## How to verify that this has the expected result
- [x] tests pass

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
