### PR TITLE
chore: Update sonatype configuration because of OSSRH sunset 🌅.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,10 @@ allprojects {
 
 nexusPublishing {
     repositories {
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("OSSRH_USERNAME"))
             password.set(System.getenv("OSSRH_PASSWORD"))
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
[OSSRH has been sunset](https://central.sonatype.org/news/20250326_ossrh_sunset/), so we need to update the publish config to be able to publish to maven central. 
Following the instructions [here](https://central.sonatype.org/pages/ossrh-eol/#central-support) to use the [OSSRH Staging API ](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/).




## Short description of the changes
Adds `nexusUrl` and `snapshotRepositoryUrl`:
```gradle
       nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
       snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
```

