### PR TITLE
feat: Create structured stack trace fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Honeycomb Android SDK changelog
 
 ## Unreleased
+
 * feat: Create structured stack trace fields
 
 ## v0.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Honeycomb Android SDK changelog
 
 ## Unreleased
+* feat: Create structured stack trace fields
 
 ## v0.0.12
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ try {
 | attributes | Attributes?      | false       | Additional attributes you would like to log along with the default ones provided. |
 | thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as attributes.    |
 
+Additionally, you will receive the exception broken down into classes, methods, and lines through the following structured stack trace attributes:
+
+- `exception.structured_stacktrace.classes` - Array of class names from each stack frame
+- `exception.structured_stacktrace.methods` - Array of method names from each stack frame
+- `exception.structured_stacktrace.lines` - Array of line numbers from each stack frame
+
 ### Android Compose
 #### Setup
 Android Compose instrumentation is included in a standalone library. Add the following to your dependencies in `build.gradle.kts`:

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -172,14 +172,10 @@ class Honeycomb {
 
             // Populate structured stacktrace fields
             val stackFrames = throwable.stackTrace
-            val classes = ArrayList<String>()
-            val methods = ArrayList<String>()
-            val lines = ArrayList<Long>()
-            for (frame in stackFrames) {
-                classes.add(frame.className)
-                methods.add(frame.methodName)
-                lines.add(frame.lineNumber.toLong())
-            }
+            val classes = stackFrames.map { it.className }
+            val methods = stackFrames.map { it.methodName }
+            val lines = stackFrames.map { it.lineNumber.toLong() }
+
             attributesBuilder
                 .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.classes"), classes)
                 .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.methods"), methods)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.Logger
@@ -168,6 +169,22 @@ class Honeycomb {
             throwable.message?.let {
                 attributesBuilder.put(EXCEPTION_MESSAGE, it)
             }
+
+            // Populate structured stacktrace fields
+            val stackFrames = throwable.stackTrace
+            val classes = ArrayList<String>()
+            val methods = ArrayList<String>()
+            val lines = ArrayList<Long>()
+            for (frame in stackFrames) {
+                classes.add(frame.className)
+                methods.add(frame.methodName)
+                lines.add(frame.lineNumber.toLong())
+            }
+            attributesBuilder
+                .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.classes"), classes)
+                .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.methods"), methods)
+                .put(AttributeKey.longArrayKey("exception.structured_stacktrace.lines"), lines)
+
 
             thread?.let {
                 attributesBuilder

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -181,7 +181,6 @@ class Honeycomb {
                 .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.methods"), methods)
                 .put(AttributeKey.longArrayKey("exception.structured_stacktrace.lines"), lines)
 
-
             thread?.let {
                 attributesBuilder
                     .put(THREAD_ID, it.id)

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -137,15 +137,7 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray")
   assert_not_empty "$result"
 
-  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray" \
-    | grep "CorePlaygroundKt")
-  assert_not_empty "$result"
-
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray")
-  assert_not_empty "$result"
-
-  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" \
-    | grep "onLogException")
   assert_not_empty "$result"
 
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray")

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -134,6 +134,23 @@ teardown_file() {
     | grep "example.CorePlaygroundKt.onLogException")
   assert_not_empty "$result"
 
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" \
+    | grep "CorePlaygroundKt")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" \
+    | grep "onLogException")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray")
+  assert_not_empty "$result"
+
   result=$(attribute_for_log_key "io.honeycomb.crash" "thread.name" "string")
   assert_equal "$result" '"main"'
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -137,7 +137,7 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray")
   assert_not_empty "$result"
 
-  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" \
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray" \
     | grep "CorePlaygroundKt")
   assert_not_empty "$result"
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -143,6 +143,13 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray")
   assert_not_empty "$result"
 
+  classes_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray" | jq 'length')
+  methods_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" | jq 'length')
+  lines_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray" | jq 'length')
+
+  assert_equal "$classes_count" "$methods_count"
+  assert_equal "$methods_count" "$lines_count"
+
   result=$(attribute_for_log_key "io.honeycomb.crash" "thread.name" "string")
   assert_equal "$result" '"main"'
 


### PR DESCRIPTION
## Short description of the changes

Breaks exceptions down into into `classes`, `methods`, and `lines` fields. The [proguard processor](https://github.com/honeycombio/opentelemetry-collector-symbolicator/tree/main/proguardprocessor) needs these fields to work.

## How to verify that this has the expected result
Tested locally.

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
