### PR TITLE
docs: improve consistency between android and IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,12 @@ try {
 | attributes | Attributes?      | false       | Additional attributes you would like to log along with the default ones provided. |
 | thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as attributes.    |
 
+
+The following attributes are automatically attached to the log entry.
+
+ * `exception.stacktrace` - The unstructured stacktrace of the exception
+ * `exception.type` - The runtime resolvable classname of the exception
+
 Additionally, you will receive the exception broken down into classes, methods, and lines through the following structured stack trace attributes:
 
 - `exception.structured_stacktrace.classes` - Array of class names from each stack frame

--- a/README.md
+++ b/README.md
@@ -27,15 +27,19 @@ For a complete list of tested dependencies and versions, see
 
 ## Getting started
 
+### build.gradle
+
 Add the following dependencies to your `build.gradle.kts`:
-```
+```kotlin
 dependencies {
   implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.12")
 }
 ```
 
+### Initializing the SDK
+
 To configure the SDK in your Application class:
-```
+```kotlin
 import io.honeycomb.opentelemetry.android.Honeycomb
 import io.honeycomb.opentelemetry.android.HoneycombOptions
 import io.opentelemetry.android.OpenTelemetryRum
@@ -376,7 +380,7 @@ Specifically, it will emit 2 kinds of span for each composable that is wrapped:
 `View Body` spans encompass just the contents of the `HoneycombInstrumentedView`, and include the following attributes:
 - `view.name` (string): the name passed to `HoneycombInstrumentedComposable`
 
-### Adding a Custom Span Processor
+## Adding a Custom Span Processor
 
 You can implement and register your own custom span processor with the Honeycomb SDK. This allows you to perform custom operations on spans before they are exported, such as adding application-specific attributes.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We had some insconsistencies between our IOS and android readmes.

- Closes #<enter issue here>

## Short description of the changes
Update the docs in various sections to make the IOS and android Readmes consistent.

## How to verify that this has the expected result

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
