### PR TITLE
rel: prep for v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.0.14
+
+* fix: fix plugin config when publishing to maven central (#142)
+
 ## v0.0.13
 
 * chore: set up distribution for gradle plugin (#140)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are the current versions of libraries we have tested for compatibility:
 
   | Dependency                                             | Version        |
   |--------------------------------------------------------|----------------|
-  | `io.honeycomb.android:honeycomb-opentelemetry-android` | `0.0.13`       |
+  | `io.honeycomb.android:honeycomb-opentelemetry-android` | `0.0.14`       |
   | `io.opentelemetry.android:core`                        | `0.11.0-alpha` |
   | `io.opentelemetry.android:android-agent`               | `0.11.0-alpha` |
   | `io.opentelemetry:opentelemetry-api`                   | `1.49.0`       |
@@ -32,7 +32,7 @@ For a complete list of tested dependencies and versions, see
 Add the following dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.13")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.14")
 }
 ```
 
@@ -337,7 +337,7 @@ Additionally, you will receive the exception broken down into classes, methods, 
 Android Compose instrumentation is included in a standalone library. Add the following to your dependencies in `build.gradle.kts`:
 ```
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android-compose:0.0.13")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android-compose:0.0.14")
 }
 ```
 


### PR DESCRIPTION
Setting up a new release with a fixed config to publish the proguard uuid plugin. Plugin is already set to v0.0.13 so it needs to be upgraded to a new version for the publish pipeline to fully work ;-;

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
