### PR TITLE
feat: Make HoneycombOptions builder extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* feat: Make `HoneycombOptions` Builder extendable
+
 ## v0.0.14
 
 * fix: fix plugin config when publishing to maven central (#142)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -192,7 +192,7 @@ data class HoneycombOptions(
     val logsProtocol: OtlpProtocol,
     val offlineCachingEnabled: Boolean,
 ) {
-    class Builder private constructor() {
+    open class Builder private constructor() {
         private var serviceVersion: String? = null
         private var apiKey: String? = null
         private var tracesApiKey: String? = null


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Kotlin classes are `final` by default which obstructs us from being able to make it visible in our React Native extensions.

- Closes #<enter issue here>

## Short description of the changes

Make the builder `open` (explicitly not `final`) allowing us to extend it.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [n/a] README is updated with documentation
