### PR TITLE
chore: remove desugaring

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "io.honeycomb.opentelemetry.android.example"
-        minSdk = 21
+        minSdk = 26
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
@@ -33,7 +33,6 @@ android {
         }
     }
     compileOptions {
-        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -62,9 +61,6 @@ android {
 }
 
 dependencies {
-    // This is required by opentelemetry-android.
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
-
     implementation(libs.opentelemetry.android.agent)
     implementation(libs.opentelemetry.android.core)
     implementation(libs.opentelemetry.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ composeBom = "2025.06.01"
 composeRuntime = "1.8.3"
 constraintlayout = "2.2.1"
 coreKtx = "1.16.0"
-desugarLibs = "2.1.5"
 espressoCore = "3.6.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -51,7 +50,6 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 auto-service-processor = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarLibs" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We suspect that a significant portion of the smoke test builds is caused by having to desugar the example app. 

- Closes #<enter issue here>

## Short description of the changes
Removing desugaring and updating the min sdk version as a test.

## How to verify that this has the expected result

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
