### PR TITLE
feat: add proguard uuid attr to logs

### DIFF
--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -81,6 +81,8 @@ private fun getProguardUuid(app: Application): String? {
 
 class Honeycomb {
     companion object {
+        private var proguardUuid: String? = null
+
         /**
          * Automatically configures OpenTelemetryRum based on values stored in the app's resources.
          */
@@ -91,6 +93,8 @@ class Honeycomb {
             if (options.debug) {
                 configureDebug(options)
             }
+
+            proguardUuid = getProguardUuid(app)
 
             val traceExporter = buildSpanExporter(options)
             val metricsExporter = buildMetricsExporter(options)
@@ -118,7 +122,7 @@ class Honeycomb {
                     .putAll(createAttributes(options.resourceAttributes))
                     .putAll(getDeviceAttributes(app))
                     .apply {
-                        getProguardUuid(app)?.let { uuid ->
+                        proguardUuid?.let { uuid ->
                             put("app.debug.proguard_uuid", uuid)
                         }
                     }.build()
@@ -180,6 +184,11 @@ class Honeycomb {
                     .builder()
                     .put(EXCEPTION_STACKTRACE, stackTraceToString(throwable))
                     .put(EXCEPTION_TYPE, throwable.javaClass.name)
+
+            // Add ProGuard UUID if available, should have been set during `configure` stage
+            proguardUuid?.let { uuid ->
+                attributesBuilder.put("app.debug.proguard_uuid", uuid)
+            }
 
             attributes?.let {
                 attributesBuilder.putAll(it)

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.bytebuddy)
     alias(libs.plugins.spotless)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.proguard.uuid)
 }
 
 android {

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="io.honeycomb.proguard.uuid"
+            android:value="${PROGUARD_UUID}" />
     </application>
 
 </manifest>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ opentelemetryBaggageProcessor = "1.46.0-alpha"
 opentelemetryInstrumentation = "2.15.0"
 opentelemetrySemConv = "1.32.0"
 opentelemetrySemConvAlpha = "1.30.0-alpha"
+proguardUUID = "0.0.16"
 publish = "2.0.0"
 spotless = "7.2.1"
 uiautomator = "2.4.0-alpha05"
@@ -77,5 +78,6 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 bytebuddy = { id = "net.bytebuddy.byte-buddy-gradle-plugin",  version.ref = "bytebuddy" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+proguard-uuid = { id = "io.honeycomb.proguard-uuid", version.ref = "proguardUUID" }
 publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -19,7 +19,8 @@ teardown_file() {
 
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | sort | uniq)
-  assert_equal "$result" '"device.id"
+  assert_equal "$result" '"app.debug.proguard_uuid"
+"device.id"
 "device.manufacturer"
 "device.model.identifier"
 "device.model.name"
@@ -141,6 +142,9 @@ teardown_file() {
   assert_not_empty "$result"
 
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray")
+  assert_not_empty "$result"
+
+  result=$(attribute_for_log_key "io.honeycomb.crash" "app.debug.proguard_uuid" "string")
   assert_not_empty "$result"
 
   classes_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray" | jq 'length')


### PR DESCRIPTION
## Short description of the changes
The `logException` function from our Android SDK creates a new attributes builder. We are currently only emitting exception attributes from this function. The issue is that our proguard processor [expects a uuid attribute](https://github.com/honeycombio/opentelemetry-collector-symbolicator/blob/9ca6539aacc448329e7eeb8a78a6b6175fe5e67a/proguardprocessor/log_processor.go#L127-L130), resulting in unsymbolicated stacktraces.

## How to verify that this has the expected result
Tests pass!

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
