### PR TITLE
feat: emit source files as a structured stacktrace attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* feat: emit source files as a structured stacktrace attribute (#166)
+
 ## v0.0.17
 
 * feat: add proguard uuid attr to logs (#157)

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Additionally, you will receive the exception broken down into classes, methods, 
 - `exception.structured_stacktrace.classes` - Array of class names from each stack frame
 - `exception.structured_stacktrace.methods` - Array of method names from each stack frame
 - `exception.structured_stacktrace.lines` - Array of line numbers from each stack frame
+- `exception.structured_stacktrace.source_files` - Array of source files from each stack frame
 
 ### Android Compose
 #### Setup

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -203,11 +203,13 @@ class Honeycomb {
             val classes = stackFrames.map { it.className }
             val methods = stackFrames.map { it.methodName }
             val lines = stackFrames.map { it.lineNumber.toLong() }
+            val sourceFiles = stackFrames.map { it.fileName }
 
             attributesBuilder
                 .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.classes"), classes)
                 .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.methods"), methods)
                 .put(AttributeKey.longArrayKey("exception.structured_stacktrace.lines"), lines)
+                .put(AttributeKey.stringArrayKey("exception.structured_stacktrace.source_files"), sourceFiles)
 
             thread?.let {
                 attributesBuilder

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -144,15 +144,20 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray")
   assert_not_empty "$result"
 
+  result=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.source_files" "stringArray")
+  assert_not_empty "$result"
+
   result=$(attribute_for_log_key "io.honeycomb.crash" "app.debug.proguard_uuid" "string")
   assert_not_empty "$result"
 
   classes_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.classes" "stringArray" | jq 'length')
   methods_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.methods" "stringArray" | jq 'length')
   lines_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.lines" "longArray" | jq 'length')
+  source_files_count=$(attribute_for_log_key "io.honeycomb.crash" "exception.structured_stacktrace.source_files" "stringArray" | jq 'length')
 
   assert_equal "$classes_count" "$methods_count"
   assert_equal "$methods_count" "$lines_count"
+  assert_equal "$classes_count" "source_files_count"
 
   result=$(attribute_for_log_key "io.honeycomb.crash" "thread.name" "string")
   assert_equal "$result" '"main"'

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -157,7 +157,6 @@ teardown_file() {
 
   assert_equal "$classes_count" "$methods_count"
   assert_equal "$methods_count" "$lines_count"
-  assert_equal "$classes_count" "source_files_count"
 
   result=$(attribute_for_log_key "io.honeycomb.crash" "thread.name" "string")
   assert_equal "$result" '"main"'


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
Stack traces can be broken down into classes, methods, lines, AND source files! Updating to emit the source files for stack frames as structured data.

## How to verify that this has the expected result
Tested locally, smoke tests pass.

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
