### PR TITLE
feat: add inline AndroidResource implementation for comprehensive resource attributes

### DIFF
--- a/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
+++ b/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith
 
 /**
  *
- * These tests are intended to exercise SKD initialization.
+ * These tests are intended to exercise SDK initialization.
  */
 @RunWith(AndroidJUnit4::class)
 class HoneycombResourceAttributesTest {

--- a/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
+++ b/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
@@ -1,50 +1,21 @@
 package io.honeycomb.opentelemetry.android.example
 
 import android.os.Build
-import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.text.intl.Locale
-import androidx.compose.ui.text.toUpperCase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.By
-import androidx.test.uiautomator.BySelector
-import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiObject2
-import androidx.test.uiautomator.Until
 import io.honeycomb.opentelemetry.android.Honeycomb
 import io.honeycomb.opentelemetry.android.HoneycombOptions
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.ServiceAttributes
-import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.File
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-
-// How long to wait for the UI to update between interactions.
-val UI_WAIT_TIMEOUT = 5.seconds
-
-// This is a special directory that will be saved to the build directory after the test finishes.
-const val ADDITIONAL_TEST_OUTPUT_DIRECTORY =
-    "/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output"
 
 /**
- * Instrumented test, which will execute on an Android device.
  *
- * These tests are primarily intended to exercise demo functionality in the test app in order to
- * make it emit various telemetry signals. The signals will then be verified by the assertions in
- * smoke-tests/smoke-e2e.bats
+ * These tests are intended to exercise SKD initialization.
  */
 @RunWith(AndroidJUnit4::class)
 class HoneycombResourceAttributesTest {

--- a/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
+++ b/core/src/androidTest/java/io/honeycomb/opentelemetry/android/HoneycombResourceAttributesTest.kt
@@ -1,0 +1,113 @@
+package io.honeycomb.opentelemetry.android.example
+
+import android.os.Build
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import io.honeycomb.opentelemetry.android.Honeycomb
+import io.honeycomb.opentelemetry.android.HoneycombOptions
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.semconv.ServiceAttributes
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+// How long to wait for the UI to update between interactions.
+val UI_WAIT_TIMEOUT = 5.seconds
+
+// This is a special directory that will be saved to the build directory after the test finishes.
+const val ADDITIONAL_TEST_OUTPUT_DIRECTORY =
+    "/sdcard/Android/media/io.honeycomb.opentelemetry.android.example/additional_test_output"
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * These tests are primarily intended to exercise demo functionality in the test app in order to
+ * make it emit various telemetry signals. The signals will then be verified by the assertions in
+ * smoke-tests/smoke-e2e.bats
+ */
+@RunWith(AndroidJUnit4::class)
+class HoneycombResourceAttributesTest {
+    @Test
+    fun resourceAttributes_areSetCorrectly() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val app = appContext.applicationContext as android.app.Application
+
+        // Configure Honeycomb with test options
+        val options =
+            HoneycombOptions
+                .builder(app)
+                .setApiKey("test-key")
+                .setServiceName("test-service")
+                .build()
+
+        Honeycomb.configure(app, options)
+
+        // Get the resource and verify attributes
+        val resource = Honeycomb.resource
+        assertNotNull("Resource should not be null", resource)
+
+        val attributes = resource.attributes
+
+        // Verify service name
+        val serviceName = attributes.get(ServiceAttributes.SERVICE_NAME)
+        assertNotNull("Service name should be set", serviceName)
+        assertEquals("test-service", serviceName)
+
+        // Verify RUM SDK version is set
+        val rumSdkVersion = attributes.get(AttributeKey.stringKey("rum.sdk.version"))
+        assertNotNull("RUM SDK version should be set", rumSdkVersion)
+
+        // Verify device attributes
+        val deviceModelName = attributes.get(AttributeKey.stringKey("device.model.name"))
+        assertNotNull("Device model name should be set", deviceModelName)
+        assertEquals(Build.MODEL, deviceModelName)
+
+        val deviceModelId = attributes.get(AttributeKey.stringKey("device.model.identifier"))
+        assertNotNull("Device model identifier should be set", deviceModelId)
+        assertEquals(Build.MODEL, deviceModelId)
+
+        val deviceManufacturer = attributes.get(AttributeKey.stringKey("device.manufacturer"))
+        assertNotNull("Device manufacturer should be set", deviceManufacturer)
+        assertEquals(Build.MANUFACTURER, deviceManufacturer)
+
+        // Verify OS attributes
+        val osName = attributes.get(AttributeKey.stringKey("os.name"))
+        assertNotNull("OS name should be set", osName)
+        assertEquals("Android", osName)
+
+        val osType = attributes.get(AttributeKey.stringKey("os.type"))
+        assertNotNull("OS type should be set", osType)
+        assertEquals("linux", osType)
+
+        val osVersion = attributes.get(AttributeKey.stringKey("os.version"))
+        assertNotNull("OS version should be set", osVersion)
+        assertEquals(Build.VERSION.RELEASE, osVersion)
+
+        val osDescription = attributes.get(AttributeKey.stringKey("os.description"))
+        assertNotNull("OS description should be set", osDescription)
+        assertTrue("OS description should contain Android Version", osDescription!!.contains("Android Version"))
+        assertTrue("OS description should contain build info", osDescription.contains("Build"))
+        assertTrue("OS description should contain API level", osDescription.contains("API level"))
+    }
+}

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings.Secure
+import io.honeycomb.opentelemetry.android.Honeycomb.Companion.configure
+import io.opentelemetry.android.BuildConfig
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
@@ -36,13 +38,17 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE
+import io.opentelemetry.semconv.ServiceAttributes
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_ID
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
 import io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.util.function.Supplier
 import kotlin.time.toJavaDuration
 
 private const val CRASH_INSTRUMENTATION_NAME = "io.honeycomb.crash"
@@ -60,7 +66,6 @@ private fun getDeviceAttributes(app: Application): Attributes {
     val builder = Attributes.builder()
 
     builder.put(DEVICE_ID, Secure.getString(app.applicationContext.contentResolver, Secure.ANDROID_ID))
-    builder.put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
 
     return builder.build()
 }
@@ -123,8 +128,7 @@ class Honeycomb {
                         .build()
                 }
 
-            resource =
-                resource
+            resource = AndroidResource.createDefault(app)
                     .toBuilder()
                     .putAll(createAttributes(options.resourceAttributes))
                     .putAll(getDeviceAttributes(app))
@@ -325,5 +329,47 @@ class Honeycomb {
             }
             return CompletableResultCode.ofAll(codes)
         }
+    }
+}
+
+// Based on: io/opentelemetry/android/AndroidResource.java
+internal object AndroidResource {
+    fun createDefault(application: Application): Resource {
+        val appName : String = getAppName(application)
+        val resourceBuilder = Resource.getDefault().toBuilder()
+
+        return resourceBuilder
+            .put(ServiceAttributes.SERVICE_NAME, appName)
+            .put("rum.sdk.version", BuildConfig.OTEL_ANDROID_VERSION)
+            .put(DeviceIncubatingAttributes.DEVICE_MODEL_NAME, Build.MODEL)
+            .put(DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER, Build.MODEL)
+            .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
+            .put(OsIncubatingAttributes.OS_NAME, "Android")
+            .put(OsIncubatingAttributes.OS_TYPE, "linux")
+            .put(OsIncubatingAttributes.OS_VERSION, Build.VERSION.RELEASE)
+            .put(OsIncubatingAttributes.OS_DESCRIPTION, getOSDescription())
+            .build()
+    }
+
+    private fun getAppName(application: Application ): String {
+        try {
+            val stringId =  application.getApplicationContext().getApplicationInfo().labelRes
+            return application.getApplicationContext().getString(stringId)
+        }  catch (e: Exception) {
+            return "unknown_service:android"
+        }
+    }
+
+    private fun getOSDescription(): String {
+        val osDescriptionBuilder = StringBuilder()
+        return osDescriptionBuilder
+            .append("Android Version ")
+            .append(Build.VERSION.RELEASE)
+            .append(" (Build ")
+            .append(Build.ID)
+            .append(" API level ")
+            .append(Build.VERSION.SDK_INT)
+            .append(")")
+            .toString()
     }
 }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -48,7 +48,6 @@ import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.function.Supplier
 import kotlin.time.toJavaDuration
 
 private const val CRASH_INSTRUMENTATION_NAME = "io.honeycomb.crash"
@@ -128,7 +127,9 @@ class Honeycomb {
                         .build()
                 }
 
-            resource = AndroidResource.createDefault(app)
+            resource =
+                AndroidResource
+                    .createDefault(app)
                     .toBuilder()
                     .putAll(createAttributes(options.resourceAttributes))
                     .putAll(getDeviceAttributes(app))
@@ -335,7 +336,7 @@ class Honeycomb {
 // Based on: io/opentelemetry/android/AndroidResource.java
 internal object AndroidResource {
     fun createDefault(application: Application): Resource {
-        val appName : String = getAppName(application)
+        val appName: String = getAppName(application)
         val resourceBuilder = Resource.getDefault().toBuilder()
 
         return resourceBuilder
@@ -351,11 +352,11 @@ internal object AndroidResource {
             .build()
     }
 
-    private fun getAppName(application: Application ): String {
+    private fun getAppName(application: Application): String {
         try {
-            val stringId =  application.getApplicationContext().getApplicationInfo().labelRes
+            val stringId = application.getApplicationContext().getApplicationInfo().labelRes
             return application.getApplicationContext().getString(stringId)
-        }  catch (e: Exception) {
+        } catch (e: Exception) {
             return "unknown_service:android"
         }
     }

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings.Secure
-import io.honeycomb.opentelemetry.android.Honeycomb.Companion.configure
 import io.opentelemetry.android.BuildConfig
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -1,5 +1,6 @@
 package io.honeycomb.opentelemetry.android.example
 
+import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -16,8 +17,14 @@ import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
+import io.honeycomb.opentelemetry.android.Honeycomb
+import io.honeycomb.opentelemetry.android.HoneycombOptions
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -207,5 +214,68 @@ class HoneycombSmokeTest {
             Until.newWindow(),
             UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
         )
+    }
+
+    @Test
+    fun resourceAttributes_areSetCorrectly() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val app = appContext.applicationContext as android.app.Application
+
+        // Configure Honeycomb with test options
+        val options =
+            HoneycombOptions
+                .builder(app)
+                .setApiKey("test-key")
+                .setServiceName("test-service")
+                .build()
+
+        Honeycomb.configure(app, options)
+
+        // Get the resource and verify attributes
+        val resource = Honeycomb.resource
+        assertNotNull("Resource should not be null", resource)
+
+        val attributes = resource.attributes
+
+        // Verify service name
+        val serviceName = attributes.get(ServiceAttributes.SERVICE_NAME)
+        assertNotNull("Service name should be set", serviceName)
+        assertEquals("test-service", serviceName)
+
+        // Verify RUM SDK version is set
+        val rumSdkVersion = attributes.get(AttributeKey.stringKey("rum.sdk.version"))
+        assertNotNull("RUM SDK version should be set", rumSdkVersion)
+
+        // Verify device attributes
+        val deviceModelName = attributes.get(AttributeKey.stringKey("device.model.name"))
+        assertNotNull("Device model name should be set", deviceModelName)
+        assertEquals(Build.MODEL, deviceModelName)
+
+        val deviceModelId = attributes.get(AttributeKey.stringKey("device.model.identifier"))
+        assertNotNull("Device model identifier should be set", deviceModelId)
+        assertEquals(Build.MODEL, deviceModelId)
+
+        val deviceManufacturer = attributes.get(AttributeKey.stringKey("device.manufacturer"))
+        assertNotNull("Device manufacturer should be set", deviceManufacturer)
+        assertEquals(Build.MANUFACTURER, deviceManufacturer)
+
+        // Verify OS attributes
+        val osName = attributes.get(AttributeKey.stringKey("os.name"))
+        assertNotNull("OS name should be set", osName)
+        assertEquals("Android", osName)
+
+        val osType = attributes.get(AttributeKey.stringKey("os.type"))
+        assertNotNull("OS type should be set", osType)
+        assertEquals("linux", osType)
+
+        val osVersion = attributes.get(AttributeKey.stringKey("os.version"))
+        assertNotNull("OS version should be set", osVersion)
+        assertEquals(Build.VERSION.RELEASE, osVersion)
+
+        val osDescription = attributes.get(AttributeKey.stringKey("os.description"))
+        assertNotNull("OS description should be set", osDescription)
+        assertTrue("OS description should contain Android Version", osDescription!!.contains("Android Version"))
+        assertTrue("OS description should contain build info", osDescription.contains("Build"))
+        assertTrue("OS description should contain API level", osDescription.contains("API level"))
     }
 }

--- a/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
+++ b/example/src/androidTest/java/io/honeycomb/opentelemetry/android/example/HoneycombSmokeTest.kt
@@ -1,6 +1,5 @@
 package io.honeycomb.opentelemetry.android.example
 
-import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -17,14 +16,8 @@ import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
-import io.honeycomb.opentelemetry.android.Honeycomb
-import io.honeycomb.opentelemetry.android.HoneycombOptions
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -214,68 +207,5 @@ class HoneycombSmokeTest {
             Until.newWindow(),
             UI_WAIT_TIMEOUT.toLong(DurationUnit.MILLISECONDS),
         )
-    }
-
-    @Test
-    fun resourceAttributes_areSetCorrectly() {
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val app = appContext.applicationContext as android.app.Application
-
-        // Configure Honeycomb with test options
-        val options =
-            HoneycombOptions
-                .builder(app)
-                .setApiKey("test-key")
-                .setServiceName("test-service")
-                .build()
-
-        Honeycomb.configure(app, options)
-
-        // Get the resource and verify attributes
-        val resource = Honeycomb.resource
-        assertNotNull("Resource should not be null", resource)
-
-        val attributes = resource.attributes
-
-        // Verify service name
-        val serviceName = attributes.get(ServiceAttributes.SERVICE_NAME)
-        assertNotNull("Service name should be set", serviceName)
-        assertEquals("test-service", serviceName)
-
-        // Verify RUM SDK version is set
-        val rumSdkVersion = attributes.get(AttributeKey.stringKey("rum.sdk.version"))
-        assertNotNull("RUM SDK version should be set", rumSdkVersion)
-
-        // Verify device attributes
-        val deviceModelName = attributes.get(AttributeKey.stringKey("device.model.name"))
-        assertNotNull("Device model name should be set", deviceModelName)
-        assertEquals(Build.MODEL, deviceModelName)
-
-        val deviceModelId = attributes.get(AttributeKey.stringKey("device.model.identifier"))
-        assertNotNull("Device model identifier should be set", deviceModelId)
-        assertEquals(Build.MODEL, deviceModelId)
-
-        val deviceManufacturer = attributes.get(AttributeKey.stringKey("device.manufacturer"))
-        assertNotNull("Device manufacturer should be set", deviceManufacturer)
-        assertEquals(Build.MANUFACTURER, deviceManufacturer)
-
-        // Verify OS attributes
-        val osName = attributes.get(AttributeKey.stringKey("os.name"))
-        assertNotNull("OS name should be set", osName)
-        assertEquals("Android", osName)
-
-        val osType = attributes.get(AttributeKey.stringKey("os.type"))
-        assertNotNull("OS type should be set", osType)
-        assertEquals("linux", osType)
-
-        val osVersion = attributes.get(AttributeKey.stringKey("os.version"))
-        assertNotNull("OS version should be set", osVersion)
-        assertEquals(Build.VERSION.RELEASE, osVersion)
-
-        val osDescription = attributes.get(AttributeKey.stringKey("os.description"))
-        assertNotNull("OS description should be set", osDescription)
-        assertTrue("OS description should contain Android Version", osDescription!!.contains("Android Version"))
-        assertTrue("OS description should contain build info", osDescription.contains("Build"))
-        assertTrue("OS description should contain API level", osDescription.contains("API level"))
     }
 }


### PR DESCRIPTION
## Summary

This PR implements an inline `AndroidResource` object that provides comprehensive resource attributes for Android telemetry data. The upstream `AndroidResource` is private, so this creates a implementation we can access.

### Key Changes

- **New AndroidResource object**: Implements `createDefault()` method that mirrors upstream functionality
- **Service name extraction**: Reads app label with fallback to "unknown_service:android"
- **Enhanced device attributes**: Model name, identifier, and manufacturer
- **Comprehensive OS details**: Android version, build info, API level, description
- **RUM SDK version**: Included from BuildConfig
- **Centralized resource creation**: Replaces manual resource building approach

### Technical Details

The `AndroidResource.createDefault()` method provides:
- Service name from application label
- Device model information (name, identifier, manufacturer)
- OS attributes (name, type, version, description)
- RUM SDK version tracking

This moves the device manufacturer attribute from the separate `getDeviceAttributes()` function into the centralized resource creation, making the code more maintainable.

### Rationale

Since the upstream `AndroidResource` class is private, we an implementation that we can access. This inline implementation provides the same functionality if/when the upstream resource becomes accessible we weill import from there.


## Test plan

- [x] Verify all resource attributes are properly set in telemetry data
- [x] Validate OS and device information accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)
