### PR TITLE
fix: set timestamp on log records in logException method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* fix: set timestamp on log records in logException method
+
 ## v0.0.19
 
 * feat: add inline AndroidResource implementation for comprehensive resource attributes (#185)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -47,6 +47,7 @@ import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.util.concurrent.TimeUnit
 import kotlin.time.toJavaDuration
 
 private const val CRASH_INSTRUMENTATION_NAME = "io.honeycomb.crash"
@@ -231,6 +232,7 @@ class Honeycomb {
             attributesBuilder.put(EVENT_NAME, "device.crash")
             logger
                 .logRecordBuilder()
+                .setTimestamp(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
                 .setAllAttributes(attributesBuilder.build())
                 .emit()
         }


### PR DESCRIPTION
The logException method was not setting a timestamp on log records, which could cause issues with log record ordering and timestamp accuracy. This fix adds a call to setTimestamp() using System.currentTimeMillis() with TimeUnit.MILLISECONDS, following the same pattern used elsewhere in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Which problem is this PR solving?

Manually logged exceptions weren't getting accurate timestamps.

## Short description of the changes

Change the code to manually call `setTimestamp`.

## How to verify that this has the expected result

This has been manually verified.

---

- [X] CHANGELOG is updated
N/A ~- [ ] README is updated with documentation~
