### PR TITLE
fix: change composable spans to avoid negative times

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,10 +13,10 @@
             <option value="$PROJECT_DIR$/compose" />
             <option value="$PROJECT_DIR$/core" />
             <option value="$PROJECT_DIR$/example" />
+            <option value="$PROJECT_DIR$/honeycomb-proguard-uuid-plugin" />
             <option value="$PROJECT_DIR$/interaction" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -61,6 +61,9 @@
     <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * fix: set timestamp on log records in logException method
 * fix: downgrade Kotlin and avoid future dependabot Kotlin upgrades
 * fix: upgrade to compile version 36 
+* fix: fix a subtle bug with incorrect timestamps in Compose render instrumentation
 
 ## v0.0.19
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ smoke-bats: smoke-tests/collector/data.json
 	@echo ""
 	cd smoke-tests && bats ./smoke-e2e.bats --report-formatter junit --output ./
 
-smoke: smoke-docker android-test smoke-bats
+smoke: unsmoke clean-smoke-tests smoke-docker android-test smoke-bats
 
 unsmoke:
 	@echo ""


### PR DESCRIPTION
## Which problem is this PR solving?

This fixes a subtle bug with Compose render spans sometimes having really long durations, when the render itself was really fast. The underlying issue is that we were using `System.currentTimeMillis` to get the time for the span to end. But the OTel Java SDK uses some trickery to keep track of timestamps with nano resolution. So, the problem was if a render finished during the same millisecond that it started, the start time would have nanos, whereas the end time would have those zeroed out. When subtracting, the duration of the span would be a small negative number. When converted to an unsigned uint64_t, the small negative number became a large positive number.

## Short description of the changes

We can't really introspect the nano-resolution clock of the tracer. So, instead, I'd like to refactor the spans so that we `end` the span when it's done, rather than merely recording the time and closing it later. This should have minimal impact on measurements.

## How to verify that this has the expected result

I don't know a good way to test this.

---

- [X] CHANGELOG is updated
N/A ~- [ ] README is updated with documentation~
