### PR TITLE
feat: add API to disable specific auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* feat: add `setDisabledInstrumentation()` API to selectively disable auto-instrumentation
 * maint: update OpenTelemetry Android SDK from 0.11.0-alpha to 1.0.0-rc.1-alpha
 
 ## v0.0.21

--- a/README.md
+++ b/README.md
@@ -205,14 +205,34 @@ To enable all OpenTelemetry auto-instrumentation, simply include `android-agent`
 * [`io.opentelemetry.android:android-agent`](https://github.com/open-telemetry/opentelemetry-android/tree/main)
 
 If you want to pick and choose which auto-instrumentation to include, you can instead add dependencies for whichever components you would like:
-* [`io.opentelemetry.android:instrumentation-activity`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/activity)
-* [`io.opentelemetry.android:instrumentation-anr`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/anr)
-* [`io.opentelemetry.android:instrumentation-crash`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/crash)
-* [`io.opentelemetry.android:instrumentation-fragment`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/fragment)
-* [`io.opentelemetry.android:instrumentation-slowrendering`](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/slowrendering)
+
+| Module              | Instrumentation Name   | Included in Agent | Description                                              | Source                                                                                                       |
+|---------------------|------------------------|-------------------|----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| activity            | `"activity"`           | Yes               | Activity lifecycle tracking (AppStart, Created, etc.)    | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/activity)        |
+| anr                 | `"anr"`                | Yes               | Application Not Responding detection (~5s threshold)     | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/anr)             |
+| crash               | `"crash"`              | Yes               | Uncaught exception reporting                             | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/crash)           |
+| fragment            | `"fragment"`           | Yes               | Fragment lifecycle tracking                              | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/fragment)        |
+| network             | `"network"`            | Yes               | Network connectivity change detection                    | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/network)         |
+| screen-orientation  | `"screen_orientation"` | Yes               | Device orientation change tracking                       | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/screen-orientation) |
+| sessions            | `"session"`            | Yes               | User session lifecycle tracking                          | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/sessions)        |
+| slowrendering       | `"slowrendering"`      | Yes               | Slow (>16ms) and frozen (>700ms) frame detection         | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/slowrendering)   |
+| startup             | `"startup"`            | Yes               | Application startup performance tracking                 | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/startup)         |
+| android-log         | `"android-log"`        | No                | Generates OTel log records from Android Log.x() calls    | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/android-log)     |
+| compose/click       | `"compose.click"`      | No                | Jetpack Compose click event tracking                     | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/compose/click)   |
+| httpurlconnection   | `"httpurlconnection"`  | No                | HttpURLConnection HTTP client tracing                    | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/httpurlconnection) |
+| okhttp3             | `"okhttp"`             | No                | OkHttp HTTP client tracing                               | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/okhttp3)         |
+| okhttp3-websocket   | `"okhttp-websocket"`   | No                | OkHttp WebSocket tracing                                 | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/okhttp3-websocket) |
+| view-click          | `"view.click"`         | No                | View click event tracking for Android Views              | [source](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/view-click)      |
 
 The following additional auto-instrumentation is implemented in this library:
-* `honeycomb-opentelemetry-android-interaction` &mdash; UI interaction in XML-based Activities.
+
+| Module      | Instrumentation Name | Included in Agent | Description                                     | Source                                                                                       |
+|-------------|----------------------|-------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------|
+| interaction | `"interaction"`      | No                | UI interaction tracking in XML-based Activities | [source](https://github.com/honeycombio/honeycomb-opentelemetry-android/tree/main/interaction) |
+
+### Disabling Auto-Instrumentation
+
+To disable specific auto-instrumentation, use the `setDisabledInstrumentation()` method with a list of instrumentation names from the tables above. For example, to disable crash and ANR reporting: `.setDisabledInstrumentation(listOf("crash", "anr"))`.
 
 ### Activity Lifecycle Instrumentation
 

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -143,6 +143,11 @@ class Honeycomb {
             val diskBufferingConfig = DiskBufferingConfig.create(options.offlineCachingEnabled)
             rumConfig.setDiskBufferingConfig(diskBufferingConfig)
 
+            // Suppress any disabled instrumentations
+            for (instrumentationName in options.disabledInstrumentation) {
+                rumConfig.suppressInstrumentation(instrumentationName)
+            }
+
             return OpenTelemetryRumBuilder
                 .create(app, rumConfig)
                 .mergeResource(resource)

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/HoneycombOptions.kt
@@ -201,6 +201,7 @@ data class HoneycombOptions(
     val metricsProtocol: OtlpProtocol,
     val logsProtocol: OtlpProtocol,
     val offlineCachingEnabled: Boolean,
+    val disabledInstrumentation: List<String>,
 ) {
     open class Builder private constructor() {
         private var serviceVersion: String? = null
@@ -241,6 +242,7 @@ data class HoneycombOptions(
         private var logsProtocol: OtlpProtocol? = null
 
         private var offlineCachingEnabled: Boolean = false
+        private var disabledInstrumentation: MutableList<String> = mutableListOf()
 
         constructor(context: Context) : this(HoneycombOptionsResourceSource(context)) {}
 
@@ -456,6 +458,11 @@ data class HoneycombOptions(
             return this
         }
 
+        fun setDisabledInstrumentation(instrumentation: List<String>): Builder {
+            disabledInstrumentation = instrumentation.toMutableList()
+            return this
+        }
+
         fun build(): HoneycombOptions {
             // Collect the non-exporter-specific values.
             val resourceAttributes = resourceAttributes.toMutableMap()
@@ -597,6 +604,7 @@ data class HoneycombOptions(
                 metricsProtocol ?: protocol,
                 logsProtocol ?: protocol,
                 offlineCachingEnabled,
+                disabledInstrumentation.toList(),
             )
         }
     }

--- a/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
+++ b/core/src/test/java/io/honeycomb/opentelemetry/android/HoneycombOptionsUnitTest.kt
@@ -94,6 +94,7 @@ class HoneycombOptionsUnitTest {
         assertFalse(options.debug)
 
         assertFalse(options.offlineCachingEnabled)
+        assertEquals(emptyList<String>(), options.disabledInstrumentation)
     }
 
     @Test
@@ -322,6 +323,7 @@ class HoneycombOptionsUnitTest {
                 .setMetricsProtocol(OtlpProtocol.HTTP_JSON)
                 .setLogsProtocol(OtlpProtocol.HTTP_JSON)
                 .setOfflineCachingEnabled(true)
+                .setDisabledInstrumentation(listOf("crash", "anr"))
                 .build()
 
         assertEquals("service", options.serviceName)
@@ -383,6 +385,7 @@ class HoneycombOptionsUnitTest {
         assertEquals(42, options.sampleRate)
         assertTrue(options.debug)
         assertTrue(options.offlineCachingEnabled)
+        assertEquals(listOf("crash", "anr"), options.disabledInstrumentation)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds `setDisabledInstrumentation()` API to selectively disable auto-instrumentation at initialization.

## Motivation

Users may want to disable specific instrumentation at runtime. The upstream `OtelRumConfig.suppressInstrumentation()` supports this, but wasn't exposed through the Honeycomb SDK.

## Changes

- Added `setDisabledInstrumentation(List<String>)` to `HoneycombOptions.Builder`
- Updated README with instrumentation tables showing available instrumentation names
- Added "Disabling Auto-Instrumentation" section with usage example

  ## Usage

```kotlin
  val options = HoneycombOptions.builder(this)
      .setApiKey("YOUR-API-KEY")
      .setDisabledInstrumentation(listOf("crash", "anr"))
      .build()
```

## Testing

-  Unit tests added to verify the API and backward compatibility (defaults to empty list).

## Documentation

- [X] CHANGELOG is updated
- [X] README is updated with documentation
