### PR TITLE
maint: Set Dependabot open pull requests limit to 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: gradle
     directory: /
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 0
     schedule:
       interval: weekly
     ignore:


### PR DESCRIPTION
Dependabot is constantly opening PRs to update our dependencies in ways that cause breaking changes for our customers. We want to limit dependabot to only updates that are needed to address security vulnerabilities.

Per GitHub's documentation, setting the pull request limit to zero will still allow GitHub to open critical security updates, while not spamming us with other update PRs.

https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates

N/A ~- [ ] CHANGELOG is updated~
N/A ~- [ ] README is updated with documentation~
