### PR TITLE
fix: add the severity to crash logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * feat: add `setDisabledInstrumentation()` API to selectively disable auto-instrumentation
 * maint: update OpenTelemetry Android SDK from 0.11.0-alpha to 1.0.0-rc.1-alpha
+* feat: add optional `severity` parameter to `logException` method
 
 ## v0.0.21
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,8 @@ try {
             AttributeKey.stringKey("user.name"), "bufo",
             AttributeKey.longKey("user.id"), 1
         ),
-        Thread.currentThread())
+        Thread.currentThread(),
+        Severity.ERROR)
 }
 ```
 
@@ -407,6 +408,7 @@ try {
 | exception  | Throwable        | true        | The exception itself. Attributes will be automatically added to the log record.   |
 | attributes | Attributes?      | false       | Additional attributes you would like to log along with the default ones provided. |
 | thread     | Thread?          | false       | Thread where the error occurred. Add this to include the thread as attributes.    |
+| severity   | Severity         | false       | Severity of the exception. Defaults to `ERROR`.                                   |
 
 
 The following attributes are automatically attached to the log entry.

--- a/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
+++ b/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.contrib.baggage.processor.BaggageLogRecordProcessor
 import io.opentelemetry.contrib.baggage.processor.BaggageSpanProcessor
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter
@@ -186,6 +187,7 @@ class Honeycomb {
             throwable: Throwable,
             attributes: Attributes? = null,
             thread: Thread? = null,
+            severity: Severity = Severity.ERROR,
         ) {
             // TODO: It would be nice to include the common RuntimeDetailsExtractor, in order to
             // augment the event with additional metadata, such as memory usage and battery percentage.
@@ -239,6 +241,8 @@ class Honeycomb {
                 .logRecordBuilder()
                 .setTimestamp(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
                 .setAllAttributes(attributesBuilder.build())
+                .setSeverity(severity)
+                .setSeverityText(severity.toString())
                 .emit()
         }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -146,6 +146,10 @@ teardown_file() {
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.message" "string")
   assert_equal "$result" '"This exception was intentional."'
 
+  result=$(logs_from_scope_named "io.honeycomb.crash" \
+    | jq 'select(.attributes[].value.stringValue == "java.lang.RuntimeException") | .severityText')
+  assert_equal "$result" '"ERROR"'
+
   result=$(attribute_for_log_key "io.honeycomb.crash" "exception.stacktrace" "string" \
     | grep "example.CorePlaygroundKt.onLogException")
   assert_not_empty "$result"


### PR DESCRIPTION

## Which problem is this PR solving?

Adds an optional parameter when manually logging errors to set the severity number and text. It defaults to `ERROR`.

## Short description of the changes

This is not a breaking change, because it's an optional parameter. The default value is `ERROR`, because these are exceptions, and since they are manually logged, they are probably not fatal.

## How to verify that this has the expected result

Smoke tests are updated.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
