### PR TITLE
rel: prepare for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.0
+
 * maint: update OpenTelemetry Android SDK from 0.11.0-alpha to 1.0.1
 * feat: add `setDisabledInstrumentation()` API to selectively disable auto-instrumentation
 * feat: add optional `severity` parameter to `logException` method

--- a/README.md
+++ b/README.md
@@ -5,19 +5,11 @@
 
 Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on Android.
 
-**STATUS: this library is in BETA.**
-We are actively seeking feedback to ensure usability.
-
-Honeycomb APIs and data shapes are stable and safe for production.
-However, this SDK depends on the OpenTelemetry Android SDK, which is still
-experimental and subject to change. Therefore, when updating, it is possible to
-encounter breaking changes in other dependencies.
-
 These are the current versions of libraries we have tested for compatibility:
 
   | Dependency                                             | Version  |
   |--------------------------------------------------------|----------|
-  | `io.honeycomb.android:honeycomb-opentelemetry-android` | `0.0.21` |
+  | `io.honeycomb.android:honeycomb-opentelemetry-android` | `1.0.0`  |
   | `io.opentelemetry.android:core`                        | `1.0.1`  |
   | `io.opentelemetry.android:android-agent`               | `1.0.1`  |
   | `io.opentelemetry:opentelemetry-api`                   | `1.57.0` |
@@ -32,7 +24,7 @@ For a complete list of tested dependencies and versions, see
 Add the following dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:0.0.21")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android:1.0.0")
 }
 ```
 
@@ -428,7 +420,7 @@ Additionally, you will receive the exception broken down into classes, methods, 
 Android Compose instrumentation is included in a standalone library. Add the following to your dependencies in `build.gradle.kts`:
 ```
 dependencies {
-  implementation("io.honeycomb.android:honeycomb-opentelemetry-android-compose:0.0.21")
+  implementation("io.honeycomb.android:honeycomb-opentelemetry-android-compose:1.0.0")
 }
 ```
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Prepares for the 1.0.0 release of the Honeycomb Android SDK.

## Short description of the changes

- This is the first release based on the 1.0.1 OpenTelemetry Android SDK, and is considered _stable_.
- I have removed the "BETA" text in the README, which refers to OTel previously being unstable.

## How to verify that this has the expected result

Smoke tests still pass.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
