### PR TITLE
fix: pin mockserver image to 5.15.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - '4318:4318'
   mock-server:
-    image: mockserver/mockserver
+    image: mockserver/mockserver:5.15.0
     volumes:
       - './smoke-tests/mock-server:/config'
     ports:


### PR DESCRIPTION
## Problem

The nightly `main` build started failing on `HoneycombSmokeTest.network_instrumentation_works` with no source changes:

```
androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 5000 ms
```

## Root cause

`docker-compose.yml` pinned the OTel collector (`otel/opentelemetry-collector:0.139.0`) but left the mock-server image **unpinned** (`mockserver/mockserver` → resolves to `:latest`). The nightly re-pulls images, and a newly published MockServer `latest` **crashes on startup** while parsing `mockserver.properties`:

```
Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class org.mockserver.configuration.ConfigurationProperties
Caused by: java.lang.ExceptionInInitializerError: java.lang.NullPointerException
	at org.mockserver.configuration.ConfigurationProperties.isSensitivePropertyName
	at org.mockserver.configuration.ConfigurationProperties.readPropertyFile
```

The container exits (code 1), so nothing listens on port 1080. The example app's request to `http://10.0.2.2:1080/simple-api` then fails with `java.net.ConnectException: Failed to connect`, `"Network Request Succeeded"` never renders, and the Compose test times out — exactly the CI symptom. The other smoke tests pass because they don't depend on MockServer.

## Fix

Pin `mockserver/mockserver:5.15.0` (last stable release), matching how the collector is already pinned, so the nightly is reproducible.

## Verification

- Reproduced the startup crash on the unpinned `:latest` image.
- Confirmed `5.15.0` starts cleanly and `/simple-api` returns `200 OK` with the expected body, via the real `docker-compose.yml` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)